### PR TITLE
incorrect configmap name

### DIFF
--- a/charts/wasp-open-api/Chart.yaml
+++ b/charts/wasp-open-api/Chart.yaml
@@ -31,4 +31,4 @@ maintainers:
 name: wasp-open-api
 sources:
   - https://github.com/digicatapult/wasp-open-api
-version: 1.0.0
+version: 1.0.1

--- a/charts/wasp-open-api/templates/configmap.yaml
+++ b/charts/wasp-open-api/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ printf "%s-configuration" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
     app.kubernetes.io/component: wasp-open-api


### PR DESCRIPTION
Fixing inability to correctly mount configmap on cronjob due to mismatched name
