### PR TITLE
Moved to openapi-merger, deprecated wasp-open-api chart

### DIFF
--- a/charts/openapi-merger/.helmignore
+++ b/charts/openapi-merger/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/openapi-merger/Chart.lock
+++ b/charts/openapi-merger/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: nginx
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.2.34
+- name: nginx
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.2.34
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 2.2.4
+digest: sha256:352797513226d6a4035b8ea1a0a4adea7583f60dc9afdde2f7a296b258c7bb57
+generated: "2023-04-26T10:53:20.971188+01:00"

--- a/charts/openapi-merger/Chart.lock
+++ b/charts/openapi-merger/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 13.2.34
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.4
-digest: sha256:352797513226d6a4035b8ea1a0a4adea7583f60dc9afdde2f7a296b258c7bb57
-generated: "2023-04-26T10:53:20.971188+01:00"
+  version: 2.13.3
+digest: sha256:a902a7e31f1a274d8fee49c0471c1af1f1c27d905ecf5009e34ea8083409701f
+generated: "2023-11-13T08:46:58.74619Z"

--- a/charts/openapi-merger/Chart.yaml
+++ b/charts/openapi-merger/Chart.yaml
@@ -1,0 +1,32 @@
+annotations:
+  licenses: Apache-2.0
+apiVersion: v2
+# renovate: image=digicatapult/openapi-merger
+appVersion: 1.0.19
+dependencies:
+  - condition: apiDocsMock.enabled
+    name: nginx
+    alias: apiDocsMockOne
+    repository: https://charts.bitnami.com/bitnami
+    version: 13.x.x
+  - condition: apiDocsMock.enabled
+    name: nginx
+    alias: apiDocsMockTwo
+    repository: https://charts.bitnami.com/bitnami
+    version: 13.x.x
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common
+    version: 2.x.x
+description: The openapi-merger is designed to merge several openapi files into one and present a unified swagger interface
+keywords:
+  - IoT
+maintainers:
+  - name: digicatapult  # Digital Catapult
+    url: https://github.com/digicatapult/helm-charts
+    email: opensource@digicatapult.org.uk
+name: openapi-merger
+sources:
+  - https://github.com/digicatapult/openapi-merger
+version: 1.0.0

--- a/charts/openapi-merger/README.md
+++ b/charts/openapi-merger/README.md
@@ -1,0 +1,305 @@
+# openapi-merger
+
+The openapi-merger is designed to merge several openapi files into one and present a unified swagger interface
+
+## TL;DR
+
+```console
+$ helm repo add digicatapult https://digicatapult.github.io/helm-charts
+$ helm install my-release digicatapult/openapi-merger
+```
+
+## Introduction
+
+This chart bootstraps a [openapi-merger](https://github.com/digicatapult/openapi-merger/) deployment on a Kubernetes cluster using the [Helm](https://helm.sh/) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```console
+$ helm repo add digicatapult https://digicatapult.github.io/helm-charts
+$ helm install my-release digicatapult/openapi-merger
+```
+
+The command deploys openapi-merger on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+helm delete my-releases
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Parameters
+
+### Global parameters
+
+| Name                      | Description                                     | Value |
+| ------------------------- | ----------------------------------------------- | ----- |
+| `global.imageRegistry`    | Global Docker image registry                    | `""`  |
+| `global.imagePullSecrets` | Global Docker registry secret names as an array | `[]`  |
+| `global.storageClass`     | Global StorageClass for Persistent Volume(s)    | `""`  |
+
+### Common parameters
+
+| Name                     | Description                                                                             | Value           |
+| ------------------------ | --------------------------------------------------------------------------------------- | --------------- |
+| `kubeVersion`            | Override Kubernetes version                                                             | `""`            |
+| `nameOverride`           | String to partially override common.names.name                                          | `""`            |
+| `fullnameOverride`       | String to fully override common.names.fullname                                          | `""`            |
+| `namespaceOverride`      | String to fully override common.names.namespace                                         | `""`            |
+| `commonLabels`           | Labels to add to all deployed objects                                                   | `{}`            |
+| `commonAnnotations`      | Annotations to add to all deployed objects                                              | `{}`            |
+| `clusterDomain`          | Kubernetes cluster domain name                                                          | `cluster.local` |
+| `extraDeploy`            | Array of extra objects to deploy with the release                                       | `[]`            |
+| `diagnosticMode.enabled` | Enable diagnostic mode (all probes will be disabled and the command will be overridden) | `false`         |
+| `diagnosticMode.command` | Command to override all containers in the deployment                                    | `["sleep"]`     |
+| `diagnosticMode.args`    | Args to override all containers in the deployment                                       | `["infinity"]`  |
+
+### openapi-merger config parameters
+
+| Name                                              | Description                                                                                                                                               | Value                                                                                                                                                                                                                 |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `logLevel`                                        | Allowed values: error, warn, info, debug                                                                                                                  | `info`                                                                                                                                                                                                                |
+| `paths`                                           | An array of URLs to the OpenAPI specs to merge                                                                                                            | `["http://wasp-reading-service/v1/api-docs","http://wasp-event-service/v1/api-docs","http://wasp-thing-service/v1/api-docs","http://wasp-authentication-service/v1/api-docs","http://wasp-user-service/v1/api-docs"]` |
+| `output`                                          | The path to the output file                                                                                                                               | `output/output.swagger.json`                                                                                                                                                                                          |
+| `baseUrl`                                         | The base URL of the API                                                                                                                                   | `http://localhost:3000/api`                                                                                                                                                                                           |
+| `apiDocsFilePath`                                 | The path to the API docs file                                                                                                                             | `/data/api-docs.json`                                                                                                                                                                                                 |
+| `prepend`                                         | what to prepend to the pathModification in the merged OpenAPI spec                                                                                        | `""`                                                                                                                                                                                                                  |
+| `openApiTitle`                                    | The title of the merged OpenAPI spec                                                                                                                      | `Merged OpenAPI spec`                                                                                                                                                                                                 |
+| `apiDocsMock.enabled`                             | Enable API docs mock                                                                                                                                      | `false`                                                                                                                                                                                                               |
+| `security`                                        | Enable JWT Bearer security configuration in the merged OpenAPI spec                                                                                       | `false`                                                                                                                                                                                                               |
+| `image.registry`                                  | openapi-merger image registry                                                                                                                             | `docker.io`                                                                                                                                                                                                           |
+| `image.repository`                                | openapi-merger image repository                                                                                                                           | `digicatapult/openapi-merger`                                                                                                                                                                                         |
+| `image.tag`                                       | openapi-merger image tag (immutable tags are recommended)                                                                                                 | `v1.0.19`                                                                                                                                                                                                             |
+| `image.digest`                                    | openapi-merger image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                                                                                                                                                                                                                  |
+| `image.pullPolicy`                                | openapi-merger image pull policy                                                                                                                          | `IfNotPresent`                                                                                                                                                                                                        |
+| `image.pullSecrets`                               | openapi-merger image pull secrets                                                                                                                         | `[]`                                                                                                                                                                                                                  |
+| `image.debug`                                     | Enable openapi-merger image debug mode                                                                                                                    | `false`                                                                                                                                                                                                               |
+| `replicaCount`                                    | Number of openapi-merger replicas to deploy                                                                                                               | `1`                                                                                                                                                                                                                   |
+| `containerPorts.http`                             | openapi-merger HTTP container port                                                                                                                        | `3000`                                                                                                                                                                                                                |
+| `livenessProbe.enabled`                           | Enable livenessProbe on openapi-merger containers                                                                                                         | `true`                                                                                                                                                                                                                |
+| `livenessProbe.path`                              | Path for to check for livenessProbe                                                                                                                       | `/health`                                                                                                                                                                                                             |
+| `livenessProbe.initialDelaySeconds`               | Initial delay seconds for livenessProbe                                                                                                                   | `10`                                                                                                                                                                                                                  |
+| `livenessProbe.periodSeconds`                     | Period seconds for livenessProbe                                                                                                                          | `10`                                                                                                                                                                                                                  |
+| `livenessProbe.timeoutSeconds`                    | Timeout seconds for livenessProbe                                                                                                                         | `5`                                                                                                                                                                                                                   |
+| `livenessProbe.failureThreshold`                  | Failure threshold for livenessProbe                                                                                                                       | `3`                                                                                                                                                                                                                   |
+| `livenessProbe.successThreshold`                  | Success threshold for livenessProbe                                                                                                                       | `1`                                                                                                                                                                                                                   |
+| `readinessProbe.enabled`                          | Enable readinessProbe on openapi-merger containers                                                                                                        | `true`                                                                                                                                                                                                                |
+| `readinessProbe.path`                             | Path for to check for readinessProbe                                                                                                                      | `/health`                                                                                                                                                                                                             |
+| `readinessProbe.initialDelaySeconds`              | Initial delay seconds for readinessProbe                                                                                                                  | `5`                                                                                                                                                                                                                   |
+| `readinessProbe.periodSeconds`                    | Period seconds for readinessProbe                                                                                                                         | `10`                                                                                                                                                                                                                  |
+| `readinessProbe.timeoutSeconds`                   | Timeout seconds for readinessProbe                                                                                                                        | `5`                                                                                                                                                                                                                   |
+| `readinessProbe.failureThreshold`                 | Failure threshold for readinessProbe                                                                                                                      | `5`                                                                                                                                                                                                                   |
+| `readinessProbe.successThreshold`                 | Success threshold for readinessProbe                                                                                                                      | `1`                                                                                                                                                                                                                   |
+| `startupProbe.enabled`                            | Enable startupProbe on openapi-merger containers                                                                                                          | `false`                                                                                                                                                                                                               |
+| `startupProbe.path`                               | Path for to check for startupProbe                                                                                                                        | `/health`                                                                                                                                                                                                             |
+| `startupProbe.initialDelaySeconds`                | Initial delay seconds for startupProbe                                                                                                                    | `30`                                                                                                                                                                                                                  |
+| `startupProbe.periodSeconds`                      | Period seconds for startupProbe                                                                                                                           | `10`                                                                                                                                                                                                                  |
+| `startupProbe.timeoutSeconds`                     | Timeout seconds for startupProbe                                                                                                                          | `5`                                                                                                                                                                                                                   |
+| `startupProbe.failureThreshold`                   | Failure threshold for startupProbe                                                                                                                        | `10`                                                                                                                                                                                                                  |
+| `startupProbe.successThreshold`                   | Success threshold for startupProbe                                                                                                                        | `1`                                                                                                                                                                                                                   |
+| `customLivenessProbe`                             | Custom livenessProbe that overrides the default one                                                                                                       | `{}`                                                                                                                                                                                                                  |
+| `customReadinessProbe`                            | Custom readinessProbe that overrides the default one                                                                                                      | `{}`                                                                                                                                                                                                                  |
+| `customStartupProbe`                              | Custom startupProbe that overrides the default one                                                                                                        | `{}`                                                                                                                                                                                                                  |
+| `resources.limits`                                | The resources limits for the openapi-merger containers                                                                                                    | `{}`                                                                                                                                                                                                                  |
+| `resources.requests`                              | The requested resources for the openapi-merger containers                                                                                                 | `{}`                                                                                                                                                                                                                  |
+| `podSecurityContext.enabled`                      | Enabled openapi-merger pods' Security Context                                                                                                             | `true`                                                                                                                                                                                                                |
+| `podSecurityContext.fsGroup`                      | Set openapi-merger pod's Security Context fsGroup                                                                                                         | `1001`                                                                                                                                                                                                                |
+| `containerSecurityContext.enabled`                | Enabled openapi-merger containers' Security Context                                                                                                       | `true`                                                                                                                                                                                                                |
+| `containerSecurityContext.runAsUser`              | Set openapi-merger containers' Security Context runAsUser                                                                                                 | `1001`                                                                                                                                                                                                                |
+| `containerSecurityContext.runAsNonRoot`           | Set openapi-merger containers' Security Context runAsNonRoot                                                                                              | `true`                                                                                                                                                                                                                |
+| `containerSecurityContext.readOnlyRootFilesystem` | Set openapi-merger containers' Security Context runAsNonRoot                                                                                              | `false`                                                                                                                                                                                                               |
+| `command`                                         | Override default container command (useful when using custom images)                                                                                      | `[]`                                                                                                                                                                                                                  |
+| `args`                                            | Override default container args (useful when using custom images)                                                                                         | `[]`                                                                                                                                                                                                                  |
+| `hostAliases`                                     | openapi-merger pods host aliases                                                                                                                          | `[]`                                                                                                                                                                                                                  |
+| `podLabels`                                       | Extra labels for openapi-merger pods                                                                                                                      | `{}`                                                                                                                                                                                                                  |
+| `podAnnotations`                                  | Annotations for openapi-merger pods                                                                                                                       | `{}`                                                                                                                                                                                                                  |
+| `podAffinityPreset`                               | Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                       | `""`                                                                                                                                                                                                                  |
+| `podAntiAffinityPreset`                           | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                  | `soft`                                                                                                                                                                                                                |
+| `pdb.create`                                      | Enable/disable a Pod Disruption Budget creation                                                                                                           | `false`                                                                                                                                                                                                               |
+| `pdb.minAvailable`                                | Minimum number/percentage of pods that should remain scheduled                                                                                            | `1`                                                                                                                                                                                                                   |
+| `pdb.maxUnavailable`                              | Maximum number/percentage of pods that may be made unavailable                                                                                            | `""`                                                                                                                                                                                                                  |
+| `autoscaling.enabled`                             | Enable autoscaling for openapi-merger                                                                                                                     | `false`                                                                                                                                                                                                               |
+| `autoscaling.minReplicas`                         | Minimum number of openapi-merger replicas                                                                                                                 | `""`                                                                                                                                                                                                                  |
+| `autoscaling.maxReplicas`                         | Maximum number of openapi-merger replicas                                                                                                                 | `""`                                                                                                                                                                                                                  |
+| `autoscaling.targetCPU`                           | Target CPU utilization percentage                                                                                                                         | `""`                                                                                                                                                                                                                  |
+| `autoscaling.targetMemory`                        | Target Memory utilization percentage                                                                                                                      | `""`                                                                                                                                                                                                                  |
+| `nodeAffinityPreset.type`                         | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`                                                                 | `""`                                                                                                                                                                                                                  |
+| `nodeAffinityPreset.key`                          | Node label key to match. Ignored if `affinity` is set                                                                                                     | `""`                                                                                                                                                                                                                  |
+| `nodeAffinityPreset.values`                       | Node label values to match. Ignored if `affinity` is set                                                                                                  | `[]`                                                                                                                                                                                                                  |
+| `affinity`                                        | Affinity for openapi-merger pods assignment                                                                                                               | `{}`                                                                                                                                                                                                                  |
+| `nodeSelector`                                    | Node labels for openapi-merger pods assignment                                                                                                            | `{}`                                                                                                                                                                                                                  |
+| `tolerations`                                     | Tolerations for openapi-merger pods assignment                                                                                                            | `[]`                                                                                                                                                                                                                  |
+| `updateStrategy.type`                             | openapi-merger statefulset strategy type                                                                                                                  | `RollingUpdate`                                                                                                                                                                                                       |
+| `priorityClassName`                               | openapi-merger pods' priorityClassName                                                                                                                    | `""`                                                                                                                                                                                                                  |
+| `topologySpreadConstraints`                       | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                                  | `[]`                                                                                                                                                                                                                  |
+| `schedulerName`                                   | Name of the k8s scheduler (other than default) for openapi-merger pods                                                                                    | `""`                                                                                                                                                                                                                  |
+| `terminationGracePeriodSeconds`                   | Seconds Redmine pod needs to terminate gracefully                                                                                                         | `""`                                                                                                                                                                                                                  |
+| `lifecycleHooks`                                  | for the openapi-merger container(s) to automate configuration before or after startup                                                                     | `{}`                                                                                                                                                                                                                  |
+| `extraEnvVars`                                    | Array with extra environment variables to add to openapi-merger nodes                                                                                     | `[]`                                                                                                                                                                                                                  |
+| `extraEnvVarsCM`                                  | Name of existing ConfigMap containing extra env vars for openapi-merger nodes                                                                             | `""`                                                                                                                                                                                                                  |
+| `extraEnvVarsSecret`                              | Name of existing Secret containing extra env vars for openapi-merger nodes                                                                                | `""`                                                                                                                                                                                                                  |
+| `extraVolumes`                                    | Optionally specify extra list of additional volumes for the openapi-merger pod(s)                                                                         | `[]`                                                                                                                                                                                                                  |
+| `extraVolumeMounts`                               | Optionally specify extra list of additional volumeMounts for the openapi-merger container(s)                                                              | `[]`                                                                                                                                                                                                                  |
+| `sidecars`                                        | Add additional sidecar containers to the openapi-merger pod(s)                                                                                            | `[]`                                                                                                                                                                                                                  |
+| `initContainers`                                  | Add additional init containers to the openapi-merger pod(s)                                                                                               | `[]`                                                                                                                                                                                                                  |
+
+### Persistence Parameters
+
+| Name                        | Description                                                                                             | Value               |
+| --------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
+| `persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `true`              |
+| `persistence.mountPath`     | Path to mount the volume at.                                                                            | `/data`             |
+| `persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
+| `persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |
+| `persistence.annotations`   | Persistent Volume Claim annotations                                                                     | `{}`                |
+| `persistence.accessModes`   | Persistent Volume Access Modes                                                                          | `["ReadWriteOnce"]` |
+| `persistence.size`          | Size of data volume                                                                                     | `1Gi`               |
+| `persistence.existingClaim` | The name of an existing PVC to use for persistence                                                      | `""`                |
+| `persistence.selector`      | Selector to match an existing Persistent Volume for WordPress data PVC                                  | `{}`                |
+| `persistence.dataSource`    | Custom PVC data source                                                                                  | `{}`                |
+
+### Traffic Exposure Parameters
+
+| Name                               | Description                                                                                                                      | Value       |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `service.type`                     | openapi-merger service type                                                                                                      | `ClusterIP` |
+| `service.ports.http`               | openapi-merger service HTTP port                                                                                                 | `3000`      |
+| `service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`        |
+| `service.clusterIP`                | openapi-merger service Cluster IP                                                                                                | `""`        |
+| `service.loadBalancerIP`           | openapi-merger service Load Balancer IP                                                                                          | `""`        |
+| `service.loadBalancerSourceRanges` | openapi-merger service Load Balancer sources                                                                                     | `[]`        |
+| `service.externalTrafficPolicy`    | openapi-merger service external traffic policy                                                                                   | `Cluster`   |
+| `service.annotations`              | Additional custom annotations for openapi-merger service                                                                         | `{}`        |
+| `service.extraPorts`               | Extra ports to expose in openapi-merger service (normally used with the `sidecars` value)                                        | `[]`        |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`      |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`        |
+| `ingress.enabled`                  | Enable ingress record generation for openapi-merger                                                                              | `true`      |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`        |
+| `ingress.hostname`                 | Default host for the ingress record                                                                                              | `""`        |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`        |
+| `ingress.paths`                    | Default paths for the ingress record                                                                                             | `[]`        |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`        |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`     |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`     |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`        |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`        |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`        |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`        |
+| `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`        |
+
+### cronJob parameters
+
+| Name                            | Description                                                                                                                                                                 | Value             |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `cronjob.schedule`              | Schedule in Cron format to save snapshots                                                                                                                                   | `*/1 * * * *`     |
+| `cronjob.historyLimit`          | Number of successful finished jobs to retain                                                                                                                                | `3`               |
+| `cronjob.podAnnotations`        | Pod annotations for cronjob pods                                                                                                                                            | `{}`              |
+| `cronjob.resources.limits`      | Cronjob container resource limits                                                                                                                                           | `{}`              |
+| `cronjob.resources.requests`    | Cronjob container resource requests                                                                                                                                         | `{}`              |
+| `cronjob.initImage.registry`    | openapi-merger cronjob init container image registry                                                                                                                        | `docker.io`       |
+| `cronjob.initImage.repository`  | openapi-merger cronjob container image repository                                                                                                                           | `node`            |
+| `cronjob.initImage.tag`         | openapi-merger cronjob container image tag (immutable tags are recommended)                                                                                                 | `hydrogen-alpine` |
+| `cronjob.initImage.digest`      | openapi-merger cronjob container image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`              |
+| `cronjob.initImage.pullPolicy`  | openapi-merger ceonjob container image pull policy                                                                                                                          | `IfNotPresent`    |
+| `cronjob.initImage.pullSecrets` | openapi-merger cronjob container image pull secrets                                                                                                                         | `[]`              |
+| `cronjob.initImage.debug`       | Enable openapi-merger cronjob container image debug mode                                                                                                                    | `false`           |
+| `cronjob.image.registry`        | openapi-merger cronjob image registry                                                                                                                                       | `docker.io`       |
+| `cronjob.image.repository`      | openapi-merger cronjob image repository                                                                                                                                     | `curlimages/curl` |
+| `cronjob.image.tag`             | openapi-merger cronjob image tag (immutable tags are recommended)                                                                                                           | `7.87.0`          |
+| `cronjob.image.digest`          | openapi-merger cronjob image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)           | `""`              |
+| `cronjob.image.pullPolicy`      | openapi-merger ceonjob image pull policy                                                                                                                                    | `IfNotPresent`    |
+| `cronjob.image.pullSecrets`     | openapi-merger cronjob image pull secrets                                                                                                                                   | `[]`              |
+| `cronjob.image.debug`           | Enable openapi-merger cronjob image debug mode                                                                                                                              | `false`           |
+| `cronjob.nodeSelector`          | Node labels for cronjob pods assignment                                                                                                                                     | `{}`              |
+| `cronjob.tolerations`           | Tolerations for cronjob pods assignment                                                                                                                                     | `[]`              |
+
+### Other Parameters
+
+| Name                                          | Description                                                      | Value  |
+| --------------------------------------------- | ---------------------------------------------------------------- | ------ |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created             | `true` |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                           | `""`   |
+| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template) | `{}`   |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account   | `true` |
+
+
+## Configuration and installation details
+
+### [Rolling VS Immutable tags](https://docs.bitnami.com/containers/how-to/understand-rolling-tags-containers/)
+
+It is strongly recommended to use immutable tags in a production environment. This ensures your deployment does not change automatically if the same tag is updated with a different image.
+
+Digital Catapult will release a new chart updating its containers if a new version of the main container, significant changes, or critical vulnerabilities exist.
+
+### Ingress
+
+This chart provides support for Ingress resources. If you have an ingress controller installed on your cluster, such as [nginx-ingress-controller](https://github.com/bitnami/charts/tree/main/bitnami/nginx-ingress-controller) or [contour](https://github.com/bitnami/charts/tree/main/bitnami/contour) you can utilize the ingress controller to serve your application.
+
+To enable Ingress integration, set `ingress.enabled` to `true`. The `ingress.hostname` property can be used to set the host name. The `ingress.tls` parameter can be used to add the TLS configuration for this host. It is also possible to have more than one host, with a separate TLS configuration for each host. [Learn more about configuring and using Ingress](https://docs.bitnami.com/kubernetes/apps/openapi-merger/configuration/configure-use-ingress/).
+
+### TLS secrets
+
+The chart also facilitates the creation of TLS secrets for use with the Ingress controller, with different options for certificate management. [Learn more about TLS secrets](https://docs.bitnami.com/kubernetes/apps/openapi-merger/administration/enable-tls/).
+
+### Additional environment variables
+
+In case you want to add extra environment variables (useful for advanced operations like custom init scripts), you can use the `extraEnvVars` property.
+
+```yaml
+extraEnvVars:
+  - name: LOG_LEVEL
+    value: error
+```
+
+Alternatively, you can use a ConfigMap or a Secret with the environment variables. To do so, use the `extraEnvVarsCM` or the `extraEnvVarsSecret` values.
+
+### Sidecars
+
+If additional containers are needed in the same pod as openapi-merger (such as additional metrics or logging exporters), they can be defined using the `sidecars` parameter. If these sidecars export extra ports, extra port definitions can be added using the `service.extraPorts` parameter. [Learn more about configuring and using sidecar containers](https://docs.bitnami.com/kubernetes/apps/openapi-merger/administration/configure-use-sidecars/).
+
+### Pod affinity
+
+This chart allows you to set your custom affinity using the `affinity` parameter. Find more information about Pod affinity in the [kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity).
+
+As an alternative, use one of the preset configurations for pod affinity, pod anti-affinity, and node affinity available at the [bitnami/common](https://github.com/bitnami/charts/tree/main/bitnami/common#affinities) chart. To do so, set the `podAffinityPreset`, `podAntiAffinityPreset`, or `nodeAffinityPreset` parameters.
+
+## Troubleshooting
+
+Find more information about how to deal with common errors related to Bitnami's Helm charts in [this troubleshooting guide](https://docs.bitnami.com/general/how-to/troubleshoot-helm-chart-issues).
+
+## License
+
+This chart is licensed under the Apache v2.0 license.
+
+Copyright &copy; 2023 Digital Catapult
+
+### Attribution
+
+This chart is adapted from The [charts]((https://github.com/bitnami/charts)) provided by [Bitnami](https://bitnami.com/) which are licensed under the Apache v2.0 License which is reproduced here:
+
+```
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/charts/openapi-merger/README.md
+++ b/charts/openapi-merger/README.md
@@ -79,7 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `prepend`                                         | what to prepend to the pathModification in the merged OpenAPI spec                                                                                        | `""`                                                                                                                                                                                                                  |
 | `openApiTitle`                                    | The title of the merged OpenAPI spec                                                                                                                      | `Merged OpenAPI spec`                                                                                                                                                                                                 |
 | `apiDocsMock.enabled`                             | Enable API docs mock                                                                                                                                      | `false`                                                                                                                                                                                                               |
-| `security`                                        | Enable JWT Bearer security configuration in the merged OpenAPI spec                                                                                       | `false`                                                                                                                                                                                                               |
+| `security`                                        | Enable JWT Bearer security configuration in the merged OpenAPI spec                                                                                       | `true`                                                                                                                                                                                                                |
 | `image.registry`                                  | openapi-merger image registry                                                                                                                             | `docker.io`                                                                                                                                                                                                           |
 | `image.repository`                                | openapi-merger image repository                                                                                                                           | `digicatapult/openapi-merger`                                                                                                                                                                                         |
 | `image.tag`                                       | openapi-merger image tag (immutable tags are recommended)                                                                                                 | `v1.0.19`                                                                                                                                                                                                             |
@@ -173,32 +173,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Traffic Exposure Parameters
 
-| Name                               | Description                                                                                                                      | Value       |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| `service.type`                     | openapi-merger service type                                                                                                      | `ClusterIP` |
-| `service.ports.http`               | openapi-merger service HTTP port                                                                                                 | `3000`      |
-| `service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`        |
-| `service.clusterIP`                | openapi-merger service Cluster IP                                                                                                | `""`        |
-| `service.loadBalancerIP`           | openapi-merger service Load Balancer IP                                                                                          | `""`        |
-| `service.loadBalancerSourceRanges` | openapi-merger service Load Balancer sources                                                                                     | `[]`        |
-| `service.externalTrafficPolicy`    | openapi-merger service external traffic policy                                                                                   | `Cluster`   |
-| `service.annotations`              | Additional custom annotations for openapi-merger service                                                                         | `{}`        |
-| `service.extraPorts`               | Extra ports to expose in openapi-merger service (normally used with the `sidecars` value)                                        | `[]`        |
-| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`      |
-| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`        |
-| `ingress.enabled`                  | Enable ingress record generation for openapi-merger                                                                              | `true`      |
-| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`        |
-| `ingress.hostname`                 | Default host for the ingress record                                                                                              | `""`        |
-| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`        |
-| `ingress.paths`                    | Default paths for the ingress record                                                                                             | `[]`        |
-| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`        |
-| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`     |
-| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`     |
-| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`        |
-| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`        |
-| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`        |
-| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`        |
-| `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`        |
+| Name                               | Description                                                                                                                      | Value                  |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `service.type`                     | openapi-merger service type                                                                                                      | `ClusterIP`            |
+| `service.ports.http`               | openapi-merger service HTTP port                                                                                                 | `3000`                 |
+| `service.nodePorts.http`           | Node port for HTTP                                                                                                               | `""`                   |
+| `service.clusterIP`                | openapi-merger service Cluster IP                                                                                                | `""`                   |
+| `service.loadBalancerIP`           | openapi-merger service Load Balancer IP                                                                                          | `""`                   |
+| `service.loadBalancerSourceRanges` | openapi-merger service Load Balancer sources                                                                                     | `[]`                   |
+| `service.externalTrafficPolicy`    | openapi-merger service external traffic policy                                                                                   | `Cluster`              |
+| `service.annotations`              | Additional custom annotations for openapi-merger service                                                                         | `{}`                   |
+| `service.extraPorts`               | Extra ports to expose in openapi-merger service (normally used with the `sidecars` value)                                        | `[]`                   |
+| `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                 |
+| `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                   |
+| `ingress.enabled`                  | Enable ingress record generation for openapi-merger                                                                              | `true`                 |
+| `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                   |
+| `ingress.hostname`                 | Default host for the ingress record                                                                                              | `openapi-merger.local` |
+| `ingress.ingressClassName`         | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                                                    | `""`                   |
+| `ingress.paths`                    | Default paths for the ingress record                                                                                             | `[]`                   |
+| `ingress.annotations`              | Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations. | `{}`                   |
+| `ingress.tls`                      | Enable TLS configuration for the host defined at `ingress.hostname` parameter                                                    | `false`                |
+| `ingress.selfSigned`               | Create a TLS secret for this ingress record using self-signed certificates generated by Helm                                     | `false`                |
+| `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                   |
+| `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                   |
+| `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                   |
+| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                   |
+| `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                   |
 
 ### cronJob parameters
 

--- a/charts/openapi-merger/ci/ct-values.yaml
+++ b/charts/openapi-merger/ci/ct-values.yaml
@@ -1,0 +1,31 @@
+paths:
+  - http://openapi-merger-apidocsmockone:80/api-docs
+  - http://openapi-merger-apidocsmocktwo:80/api-docs
+apidocsmock:
+  enabled: true
+apidocsmockone:
+  service:
+    type: ClusterIP
+  containerPorts:
+    http: 8080
+  serverBlock: |-
+    server {
+      listen 0.0.0.0:8080;
+      location /api-docs {
+        add_header Content-Type "application/json";
+        return 200 "{\"openapi\":\"3.0.3\",\"info\":{\"title\":\"Mock 1\",\"version\":\"0.0.1\"},\"paths\":{\"/thing\":{\"parameters\":[],\"get\":{\"summary\":\"Get things\",\"tags\":[\"thing\"]}}}}";
+      }
+    }
+apidocsmocktwo:
+  service:
+    type: ClusterIP
+  containerPorts:
+    http: 8080
+  serverBlock: |-
+    server {
+      listen 0.0.0.0:8080;
+      location /api-docs {
+        add_header Content-Type "application/json";
+        return 200 "{\"openapi\":\"3.0.3\",\"info\":{\"title\":\"Mock 2\",\"version\":\"0.0.1\"},\"paths\":{\"/token\":{\"parameters\":[],\"get\":{\"summary\":\"Get authorization token\",\"tags\":[\"auth\"]}}}}";
+      }
+    }

--- a/charts/openapi-merger/templates/NOTES.txt
+++ b/charts/openapi-merger/templates/NOTES.txt
@@ -1,0 +1,59 @@
+CHART NAME: {{ .Chart.Name  }}
+CHART VERSION: {{ .Chart.Version  }}
+APP VERSION: {{ .Chart.AppVersion  }}
+
+** Please be patient while the chart is being deployed **
+
+{{- if .Values.diagnosticMode.enabled }}
+The chart has been deployed in diagnostic mode. All probes have been disabled and the command has been overwritten with:
+
+  command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 4 }}
+  args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 4 }}
+
+Get the list of pods by executing:
+
+  kubectl get pods --namespace {{ include "common.names.namespace" . | quote }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+Access the pod you want to debug by executing
+
+  kubectl exec --namespace {{ include "common.names.namespace" . | quote }} -ti <NAME OF THE POD> -- bash
+
+In order to replicate the container startup scripts execute this command:
+
+    node ./app/index.js
+
+{{- else }}
+
+1. Get a openapi-merger URL by running these commands:
+
+{{- if contains "NodePort" .Values.service.type }}
+
+    export NODE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "common.names.fullname" . }})
+    export NODE_IP=$(kubectl get nodes --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo "http://${NODE_IP}:${NODE_PORT}"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status of by running 'kubectl get --namespace {{ include "common.names.namespace" . }} svc -w {{ template "common.names.fullname" . }}'
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].port}" services {{ template "common.names.fullname" . }})
+    export SERVICE_IP=$(kubectl get svc --namespace {{ include "common.names.namespace" . }} {{ template "common.names.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo "http://${SERVICE_IP}:${SERVICE_PORT}"
+
+{{- else if contains "ClusterIP" .Values.service.type }}
+
+    export SERVICE_PORT=$(kubectl get --namespace {{ include "common.names.namespace" . }} -o jsonpath="{.spec.ports[0].port}" services {{ template "common.names.fullname" . }})
+    kubectl port-forward --namespace {{ include "common.names.namespace" . }} svc/{{ template "common.names.fullname" . }} ${SERVICE_PORT}:${SERVICE_PORT} &
+    echo "http://127.0.0.1:${SERVICE_PORT}"
+
+{{- end }}
+
+2. Access openapi-merger using the obtained URL. For example for the ClusterIP url http://127.0.0.1:3000:
+
+curl http://127.0.0.1:3000/health
+
+{{- end }}
+
+{{- include "common.warnings.rollingTag" .Values.image }}
+{{- include "openapi-merger.validateValues" . }}

--- a/charts/openapi-merger/templates/_helpers.tpl
+++ b/charts/openapi-merger/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+
+{{/*
+Return the proper openapi-merger image name
+*/}}
+{{- define "openapi-merger.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "openapi-merger.imagePullSecrets" -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.cronjob.initImage .Values.cronjob.image ) "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "openapi-merger.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "common.names.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the proper cronjob init container image name
+*/}}
+{{- define "openapi-merger.cronjob.initImage" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.cronjob.initImage "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Return the proper cronjob container image name
+*/}}
+{{- define "openapi-merger.cronjob.image" -}}
+{{ include "common.images.image" (dict "imageRoot" .Values.cronjob.image "global" .Values.global) }}
+{{- end -}}
+
+{{/*
+Compile all warnings into a single message, and call fail.
+*/}}
+{{- define "openapi-merger.validateValues" -}}
+{{- $messages := list -}}
+{{- $messages := without $messages "" -}}
+{{- $message := join "\n" $messages -}}
+
+{{- if $message -}}
+{{-   printf "\nVALUES VALIDATION:\n%s" $message | fail -}}
+{{- end -}}
+{{- end -}}

--- a/charts/openapi-merger/templates/configmap.yaml
+++ b/charts/openapi-merger/templates/configmap.yaml
@@ -1,0 +1,53 @@
+{{- $prepend  := .Values.prepend -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+data:
+  openapi-merge.yaml: |
+    inputs:
+    - inputFile: base.json
+    {{- range .Values.paths }}
+    - inputURL: {{ . }}
+    {{- if (not (empty $prepend)) }}
+      pathModification:
+        prepend: {{ $prepend  }}
+    {{- end }}
+    {{- end }}
+    output: {{ .Values.output }}
+  base.json: |
+    {
+      "openapi": "3.0.3",
+      "info": {
+        "title": {{ .Values.openApiTitle | quote }},
+        "version": "0.0.1"
+      },
+      "servers": [
+        {
+          "url": {{ .Values.baseUrl | quote }}
+        }
+      {{- if .Values.security }}
+      ],
+      "components": {
+        "securitySchemes": {
+          "BearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT"
+          }
+        }
+      },
+      "security": [{ "BearerAuth": [] }]
+      {{- else }}
+      ]
+      {{- end }}
+    }

--- a/charts/openapi-merger/templates/cronjob.yaml
+++ b/charts/openapi-merger/templates/cronjob.yaml
@@ -1,0 +1,101 @@
+apiVersion: {{ include "common.capabilities.cronjob.apiVersion" . }}
+kind: CronJob
+metadata:
+  name: {{ printf "%s-cron" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  concurrencyPolicy: Forbid
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.historyLimit }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels: {{- include "common.labels.standard" . | nindent 12 }}
+            app.kubernetes.io/component: openapi-merger
+          {{- if .Values.cronjob.podAnnotations }}
+          annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.cronjob.podAnnotations "context" $) | nindent 12 }}
+          {{- end }}
+        spec:
+          {{- if .Values.cronjob.nodeSelector }}
+          nodeSelector: {{-  toYaml .Values.cronjob.nodeSelector | nindent 12  }}
+          {{- end }}
+          {{- if .Values.cronjob.tolerations }}
+          tolerations: {{- toYaml .Values.cronjob.tolerations | nindent 12 }}
+          {{- end }}
+          {{- include "openapi-merger.imagePullSecrets" . | nindent 10 }}
+          restartPolicy: OnFailure
+          {{- if .Values.podSecurityContext.enabled }}
+          securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ printf "%s-config" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+            - name: output
+              emptyDir: {}
+          initContainers:
+            - name: openapi-merge
+              image: {{ include "openapi-merger.cronjob.initImage" . }}
+              imagePullPolicy: {{ .Values.cronjob.initImage.pullPolicy | quote }}
+              {{- if .Values.containerSecurityContext.enabled }}
+              securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}
+              {{- end }}
+              command: 
+                - sh 
+                - -c
+                - |
+                  npx openapi-merge-cli --config /etc/openapi-merge-cli/openapi-merge.yaml
+              env:
+                - name: npm_config_cache
+                  value: "/tmp/.npm"
+              {{- if .Values.cronjob.resources }}
+              resources: {{- include "common.tplvalues.render" (dict "value" .Values.cronjob.resources "context" $) | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: config
+                  mountPath: /etc/openapi-merge-cli/openapi-merge.yaml
+                  subPath: openapi-merge.yaml
+                - name: config
+                  mountPath: /etc/openapi-merge-cli/base.json
+                  subPath: base.json
+                - name: output
+                  mountPath: /etc/openapi-merge-cli/output
+          containers:
+            - name: openapi-merger-snapshotter
+              image: {{ include "openapi-merger.cronjob.image" . }}
+              imagePullPolicy: {{ .Values.cronjob.image.pullPolicy | quote }}
+              {{- if .Values.containerSecurityContext.enabled }}
+              securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 16 }}
+              {{- end }}
+              {{- if .Values.diagnosticMode.enabled }}
+              command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 16 }}
+              args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 16 }}
+              {{- else }}
+              command:
+                - sh
+                - -c 
+                - |
+                  curl -X POST -H "Content-Type: application/json" -d @/etc/openapi-merge-cli/output/output.swagger.json http://$HOST:$PORT/set-api-docs
+              {{- end }}
+              env:
+                - name: DEBUG
+                  value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+                - name: HOST
+                  value: {{ include "common.names.fullname" . }}
+                - name : PORT
+                  value: {{ .Values.service.ports.http | quote }} 
+              {{- if .Values.cronjob.resources }}
+              resources: {{- toYaml .Values.cronjob.resources | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: output
+                  mountPath: /etc/openapi-merge-cli/output

--- a/charts/openapi-merger/templates/deployment.yaml
+++ b/charts/openapi-merger/templates/deployment.yaml
@@ -1,0 +1,170 @@
+apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+kind: Deployment
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  {{- if .Values.updateStrategy }}
+  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: openapi-merger
+  template:
+    metadata:
+      {{- if .Values.podAnnotations }}
+      annotations: {{- include "common.tplvalues.render" (dict "value" .Values.podAnnotations "context" $) | nindent 8 }}
+      {{- end }}
+      labels: {{- include "common.labels.standard" . | nindent 8 }}
+        app.kubernetes.io/component: openapi-merger
+        {{- if .Values.podLabels }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.podLabels "context" $) | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "openapi-merger.serviceAccountName" . }}
+      {{- include "openapi-merger.imagePullSecrets" . | nindent 6 }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- include "common.tplvalues.render" ( dict "value" .Values.affinity "context" $) | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAffinityPreset "component" "openapi-merger" "context" $) | nindent 10 }}
+        podAntiAffinity: {{- include "common.affinities.pods" (dict "type" .Values.podAntiAffinityPreset "component" "openapi-merger" "context" $) | nindent 10 }}
+        nodeAffinity: {{- include "common.affinities.nodes" (dict "type" .Values.nodeAffinityPreset.type "key" .Values.nodeAffinityPreset.key "values" .Values.nodeAffinityPreset.values) | nindent 10 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector: {{- include "common.tplvalues.render" ( dict "value" .Values.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations: {{- include "common.tplvalues.render" (dict "value" .Values.tolerations "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.schedulerName }}
+      schedulerName: {{ .Values.schedulerName | quote }}
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      {{- if .Values.initContainers  }}
+      initContainers:
+          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: openapi-merger
+          image: {{ template "openapi-merger.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.command "context" $) | nindent 12 }}
+          {{- else if .Values.command }}
+          command: {{- include "common.tplvalues.render" (dict "value" .Values.command "context" $) | nindent 12 }}
+          {{- end }}
+          {{- if .Values.diagnosticMode.enabled }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.diagnosticMode.args "context" $) | nindent 12 }}
+          {{- else if .Values.args }}
+          args: {{- include "common.tplvalues.render" (dict "value" .Values.args "context" $) | nindent 12 }}
+          {{- end }}
+          env:
+            - name: DEBUG
+              value: {{ ternary "true" "false" (or .Values.image.debug .Values.diagnosticMode.enabled) | quote }}
+            - name: PORT
+              value: {{ .Values.containerPorts.http | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
+            {{- if .Values.apiDocsFilePath }}
+            - name: API_DOCS_FILE_PATH
+              value: {{ .Values.apiDocsFilePath }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- if .Values.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          {{- if .Values.resources }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPorts.http }}
+          {{- if not .Values.diagnosticMode.enabled }}
+          {{- if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.livenessProbe.enabled }}
+          livenessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.livenessProbe "enabled" "path") "context" $) | nindent 12 }}
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: http
+          {{- end }}
+          {{- if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
+          {{- else if .Values.readinessProbe.enabled }}
+          readinessProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.readinessProbe "enabled" "path") "context" $) | nindent 12 }}
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: http
+          {{- end }}
+          {{- if .Values.customStartupProbe }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}
+          {{- else if .Values.startupProbe.enabled }}
+          startupProbe: {{- include "common.tplvalues.render" (dict "value" (omit .Values.startupProbe "enabled" "path") "context" $) | nindent 12 }}
+            httpGet:
+              path: {{ .Values.startupProbe.path }}
+              port: http
+          {{- end }}
+          {{- end }}
+          {{- if .Values.lifecycleHooks }}
+          lifecycle: {{- include "common.tplvalues.render" (dict "value" .Values.lifecycleHooks "context" $) | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+          {{- end }}
+        {{- if .Values.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.sidecars "context" $) | nindent 8 }}
+        {{- end }}
+      volumes:
+        - name: data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "common.names.fullname" .) .Values.persistence.existingClaim }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- if .Values.extraVolumes }}
+        {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
+        {{- end }}

--- a/charts/openapi-merger/templates/extra-list.yaml
+++ b/charts/openapi-merger/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/openapi-merger/templates/hpa.yaml
+++ b/charts/openapi-merger/templates/hpa.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: {{ include "common.capabilities.hpa.apiVersion" . }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
+    kind: Deployment
+    name: {{ include "common.names.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemory  }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemory }}
+        {{- end }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        {{- if semverCompare "<1.23-0" (include "common.capabilities.kubeVersion" .) }}
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPU }}
+        {{- else }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPU }}
+        {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/openapi-merger/templates/ingress.yaml
+++ b/charts/openapi-merger/templates/ingress.yaml
@@ -1,0 +1,83 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.ingress.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+          {{- end }}
+    {{- else }}
+    - http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          {{- range .Values.ingress.paths }}
+          - path: {{ .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+          {{- end }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
+          {{- end }}
+    {{- end }}
+    {{- if .Values.ingress.extraRules }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
+    {{- end }}
+  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  tls:
+    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/openapi-merger/templates/pdb.yaml
+++ b/charts/openapi-merger/templates/pdb.yaml
@@ -1,0 +1,26 @@
+{{- $replicaCount := int .Values.replicaCount }}
+{{- if and .Values.pdb.create (or (gt $replicaCount 1) .Values.autoscaling.enabled) }}
+apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end  }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end  }}
+  selector:
+    matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
+      app.kubernetes.io/component: openapi-merger
+{{- end }}

--- a/charts/openapi-merger/templates/pvc.yaml
+++ b/charts/openapi-merger/templates/pvc.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.persistence.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.persistence.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.persistence.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  accessModes:
+  {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.selector }}
+  selector: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.selector "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if .Values.persistence.dataSource }}
+  dataSource: {{- include "common.tplvalues.render" (dict "value" .Values.persistence.dataSource "context" $) | nindent 4 }}
+  {{- end }}
+  {{- include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global) | nindent 2 }}
+{{- end -}}

--- a/charts/openapi-merger/templates/service-account.yaml
+++ b/charts/openapi-merger/templates/service-account.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "openapi-merger.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.serviceAccount.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.serviceAccount.annotations "context" $) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/charts/openapi-merger/templates/service.yaml
+++ b/charts/openapi-merger/templates/service.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "common.names.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP (eq .Values.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.service.type "LoadBalancer") (eq .Values.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+    - name: http
+      port: {{ .Values.service.ports.http }}
+      protocol: TCP
+      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.http)) }}
+      nodePort: {{ .Values.service.nodePorts.http }}
+      {{- else if eq .Values.service.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- if .Values.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector: {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger

--- a/charts/openapi-merger/templates/tls-secret.yaml
+++ b/charts/openapi-merger/templates/tls-secret.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.ingress.enabled }}
+{{- if .Values.ingress.secrets }}
+{{- range .Values.ingress.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .name }}
+  namespace: {{ include "common.names.namespace" $ | quote }}
+  labels: {{- include "common.labels.standard" $ | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if $.Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" $.Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if $.Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $.Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .certificate | b64enc }}
+  tls.key: {{ .key | b64enc }}
+---
+{{- end }}
+{{- end }}
+{{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
+{{- $ca := genCA "openapi-merger-ca" 365 }}
+{{- $cert := genSignedCert .Values.ingress.hostname nil (list .Values.ingress.hostname) 365 $ca }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tls" .Values.ingress.hostname }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: openapi-merger
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert.Cert | b64enc | quote }}
+  tls.key: {{ $cert.Key | b64enc | quote }}
+  ca.crt: {{ $ca.Cert | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/openapi-merger/values.yaml
+++ b/charts/openapi-merger/values.yaml
@@ -1,0 +1,712 @@
+## @section Global parameters
+## Global Docker image parameters
+## Please, note that this will override the image parameters, including dependencies, configured to use the global value
+## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
+##
+
+## @param global.imageRegistry Global Docker image registry
+## @param global.imagePullSecrets Global Docker registry secret names as an array
+## @param global.storageClass Global StorageClass for Persistent Volume(s)
+##
+global:
+  imageRegistry: ""
+  ## E.g.
+  ## imagePullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  imagePullSecrets: []
+  storageClass: ""
+
+## @section Common parameters
+##
+
+## @param kubeVersion Override Kubernetes version
+##
+kubeVersion: ""
+## @param nameOverride String to partially override common.names.name
+##
+nameOverride: ""
+## @param fullnameOverride String to fully override common.names.fullname
+##
+fullnameOverride: ""
+## @param namespaceOverride String to fully override common.names.namespace
+##
+namespaceOverride: ""
+## @param commonLabels Labels to add to all deployed objects
+##
+commonLabels: {}
+## @param commonAnnotations Annotations to add to all deployed objects
+##
+commonAnnotations: {}
+## @param clusterDomain Kubernetes cluster domain name
+##
+clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
+
+## Enable diagnostic mode in the deployment
+##
+diagnosticMode:
+  ## @param diagnosticMode.enabled Enable diagnostic mode (all probes will be disabled and the command will be overridden)
+  ##
+  enabled: false
+  ## @param diagnosticMode.command Command to override all containers in the deployment
+  ##
+  command:
+    - sleep
+  ## @param diagnosticMode.args Args to override all containers in the deployment
+  ##
+  args:
+    - infinity
+
+## @section openapi-merger config parameters
+##
+
+## @param logLevel Allowed values: error, warn, info, debug
+##
+logLevel: "info"
+## @param paths An array of URLs to the OpenAPI specs to merge
+##
+paths:
+  - http://wasp-reading-service/v1/api-docs
+  - http://wasp-event-service/v1/api-docs
+  - http://wasp-thing-service/v1/api-docs
+  - http://wasp-authentication-service/v1/api-docs
+  - http://wasp-user-service/v1/api-docs
+## @param output The path to the output file
+##
+output: output/output.swagger.json
+## @param baseUrl The base URL of the API
+##
+baseUrl: http://localhost:3000/api
+## @param apiDocsFilePath The path to the API docs file
+##
+apiDocsFilePath: /data/api-docs.json
+## @param prepend what to prepend to the pathModification in the merged OpenAPI spec
+##
+prepend: ""
+## @param openApiTitle The title of the merged OpenAPI spec
+##
+openApiTitle: "Merged OpenAPI spec"
+## @param apiDocsMock.enabled Enable API docs mock
+##
+apiDocsMock:
+  enabled: false
+## @param security Enable JWT Bearer security configuration in the merged OpenAPI spec
+##
+security: false
+
+## Digital Catapult openapi-merger image
+## ref: https://hub.docker.com/r/digicatapult/openapi-merger/tags/
+## @param image.registry openapi-merger image registry
+## @param image.repository openapi-merger image repository
+## @param image.tag openapi-merger image tag (immutable tags are recommended)
+## @param image.digest openapi-merger image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+## @param image.pullPolicy openapi-merger image pull policy
+## @param image.pullSecrets openapi-merger image pull secrets
+## @param image.debug Enable openapi-merger image debug mode
+##
+image:
+  registry: docker.io
+  repository: digicatapult/openapi-merger
+  tag: v1.0.19
+  digest: ""
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## e.g:
+  ## pullSecrets:
+  ##   - myRegistryKeySecretName
+  ##
+  pullSecrets: []
+  ## Enable debug mode
+  ##
+  debug: false
+## @param replicaCount Number of openapi-merger replicas to deploy
+##
+replicaCount: 1
+## @param containerPorts.http openapi-merger HTTP container port
+##
+containerPorts:
+  http: 3000
+## Configure extra options for openapi-merger containers' liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+## @param livenessProbe.enabled Enable livenessProbe on openapi-merger containers
+## @param livenessProbe.path Path for to check for livenessProbe
+## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold Success threshold for livenessProbe
+##
+livenessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+  successThreshold: 1
+## @param readinessProbe.enabled Enable readinessProbe on openapi-merger containers
+## @param readinessProbe.path Path for to check for readinessProbe
+## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold Success threshold for readinessProbe
+##
+readinessProbe:
+  enabled: true
+  path: /health
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 5
+  successThreshold: 1
+## @param startupProbe.enabled Enable startupProbe on openapi-merger containers
+## @param startupProbe.path Path for to check for startupProbe
+## @param startupProbe.initialDelaySeconds Initial delay seconds for startupProbe
+## @param startupProbe.periodSeconds Period seconds for startupProbe
+## @param startupProbe.timeoutSeconds Timeout seconds for startupProbe
+## @param startupProbe.failureThreshold Failure threshold for startupProbe
+## @param startupProbe.successThreshold Success threshold for startupProbe
+##
+startupProbe:
+  enabled: false
+  path: /health
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 10
+  successThreshold: 1
+## @param customLivenessProbe Custom livenessProbe that overrides the default one
+##
+customLivenessProbe: {}
+## @param customReadinessProbe Custom readinessProbe that overrides the default one
+##
+customReadinessProbe: {}
+## @param customStartupProbe Custom startupProbe that overrides the default one
+##
+customStartupProbe: {}
+## openapi-merger resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+## @param resources.limits The resources limits for the openapi-merger containers
+## @param resources.requests The requested resources for the openapi-merger containers
+##
+resources:
+  limits: {}
+  requests: {}
+## Configure Pods Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+## @param podSecurityContext.enabled Enabled openapi-merger pods' Security Context
+## @param podSecurityContext.fsGroup Set openapi-merger pod's Security Context fsGroup
+##
+podSecurityContext:
+  enabled: true
+  fsGroup: 1001
+## Configure Container Security Context
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+## @param containerSecurityContext.enabled Enabled openapi-merger containers' Security Context
+## @param containerSecurityContext.runAsUser Set openapi-merger containers' Security Context runAsUser
+## @param containerSecurityContext.runAsNonRoot Set openapi-merger containers' Security Context runAsNonRoot
+## @param containerSecurityContext.readOnlyRootFilesystem Set openapi-merger containers' Security Context runAsNonRoot
+##
+containerSecurityContext:
+  enabled: true
+  runAsUser: 1001
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
+
+## @param command Override default container command (useful when using custom images)
+##
+command: []
+## @param args Override default container args (useful when using custom images)
+##
+args: []
+## @param hostAliases openapi-merger pods host aliases
+## https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/
+##
+hostAliases: []
+## @param podLabels Extra labels for openapi-merger pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+##
+podLabels: {}
+## @param podAnnotations Annotations for openapi-merger pods
+## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+##
+podAnnotations: {}
+## @param podAffinityPreset Pod affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAffinityPreset: ""
+## @param podAntiAffinityPreset Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity
+##
+podAntiAffinityPreset: soft
+## Pod Disruption Budget configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb
+## @param pdb.create Enable/disable a Pod Disruption Budget creation
+## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
+## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
+##
+pdb:
+  create: false
+  minAvailable: 1
+  maxUnavailable: ""
+## Autoscaling configuration
+## ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+## @param autoscaling.enabled Enable autoscaling for openapi-merger
+## @param autoscaling.minReplicas Minimum number of openapi-merger replicas
+## @param autoscaling.maxReplicas Maximum number of openapi-merger replicas
+## @param autoscaling.targetCPU Target CPU utilization percentage
+## @param autoscaling.targetMemory Target Memory utilization percentage
+##
+autoscaling:
+  enabled: false
+  minReplicas: ""
+  maxReplicas: ""
+  targetCPU: ""
+  targetMemory: ""
+## Node affinity preset
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity
+##
+nodeAffinityPreset:
+  ## @param nodeAffinityPreset.type Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard`
+  ##
+  type: ""
+  ## @param nodeAffinityPreset.key Node label key to match. Ignored if `affinity` is set
+  ##
+  key: ""
+  ## @param nodeAffinityPreset.values Node label values to match. Ignored if `affinity` is set
+  ## E.g.
+  ## values:
+  ##   - e2e-az1
+  ##   - e2e-az2
+  ##
+  values: []
+## @param affinity Affinity for openapi-merger pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+## NOTE: `podAffinityPreset`, `podAntiAffinityPreset`, and `nodeAffinityPreset` will be ignored when it's set
+##
+affinity: {}
+## @param nodeSelector Node labels for openapi-merger pods assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+## @param tolerations Tolerations for openapi-merger pods assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+## @param updateStrategy.type openapi-merger statefulset strategy type
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+##
+updateStrategy:
+  ## StrategyType
+  ## Can be set to RollingUpdate or OnDelete
+  ##
+  type: RollingUpdate
+
+## @param priorityClassName openapi-merger pods' priorityClassName
+##
+priorityClassName: ""
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: []
+## @param schedulerName Name of the k8s scheduler (other than default) for openapi-merger pods
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+schedulerName: ""
+## @param terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
+##
+terminationGracePeriodSeconds: ""
+## @param lifecycleHooks for the openapi-merger container(s) to automate configuration before or after startup
+##
+lifecycleHooks: {}
+## @param extraEnvVars Array with extra environment variables to add to openapi-merger nodes
+## e.g:
+## extraEnvVars:
+##   - name: FOO
+##     value: "bar"
+##
+extraEnvVars: []
+## @param extraEnvVarsCM Name of existing ConfigMap containing extra env vars for openapi-merger nodes
+##
+extraEnvVarsCM: ""
+## @param extraEnvVarsSecret Name of existing Secret containing extra env vars for openapi-merger nodes
+##
+extraEnvVarsSecret: ""
+## @param extraVolumes Optionally specify extra list of additional volumes for the openapi-merger pod(s)
+##
+extraVolumes: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the openapi-merger container(s)
+##
+extraVolumeMounts: []
+## @param sidecars Add additional sidecar containers to the openapi-merger pod(s)
+## e.g:
+## sidecars:
+##   - name: your-image-name
+##     image: your-image
+##     imagePullPolicy: Always
+##     ports:
+##       - name: portname
+##         containerPort: 1234
+##
+sidecars: []
+## @param initContainers Add additional init containers to the openapi-merger pod(s)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## e.g:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'echo "hello world"']
+##
+initContainers: []
+
+## @section Persistence Parameters
+##
+
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+persistence:
+  ## @param persistence.enabled Enable persistence using Persistent Volume Claims
+  ##
+  enabled: true
+  ## @param persistence.mountPath Path to mount the volume at.
+  ##
+  mountPath: /data
+  ## @param persistence.subPath The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services
+  ##
+  subPath: ""
+  ## @param persistence.storageClass Storage class of backing PVC
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  ## @param persistence.annotations Persistent Volume Claim annotations
+  ##
+  annotations: {}
+  ## @param persistence.accessModes Persistent Volume Access Modes
+  ##
+  accessModes:
+    - ReadWriteOnce
+  ## @param persistence.size Size of data volume
+  ##
+  size: 1Gi
+  ## @param persistence.existingClaim The name of an existing PVC to use for persistence
+  ##
+  existingClaim: ""
+  ## @param persistence.selector Selector to match an existing Persistent Volume for WordPress data PVC
+  ## If set, the PVC can't have a PV dynamically provisioned for it
+  ## E.g.
+  ## selector:
+  ##   matchLabels:
+  ##     app: my-app
+  ##
+  selector: {}
+  ## @param persistence.dataSource Custom PVC data source
+  ##
+  dataSource: {}
+
+## @section Traffic Exposure Parameters
+##
+
+## openapi-merger service parameters
+##
+service:
+  ## @param service.type openapi-merger service type
+  ##
+  type: ClusterIP
+  ## @param service.ports.http openapi-merger service HTTP port
+  ##
+  ports:
+    http: 3000
+  ## Node ports to expose
+  ## @param service.nodePorts.http Node port for HTTP
+  ## NOTE: choose port between <30000-32767>
+  ##
+  nodePorts:
+    http: ""
+  ## @param service.clusterIP openapi-merger service Cluster IP
+  ## e.g.:
+  ## clusterIP: None
+  ##
+  clusterIP: ""
+  ## @param service.loadBalancerIP openapi-merger service Load Balancer IP
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+  ##
+  loadBalancerIP: ""
+  ## @param service.loadBalancerSourceRanges openapi-merger service Load Balancer sources
+  ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+  ## e.g:
+  ## loadBalancerSourceRanges:
+  ##   - 10.10.10.0/24
+  ##
+  loadBalancerSourceRanges: []
+  ## @param service.externalTrafficPolicy openapi-merger service external traffic policy
+  ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+  ##
+  externalTrafficPolicy: Cluster
+  ## @param service.annotations Additional custom annotations for openapi-merger service
+  ##
+  annotations: {}
+  ## @param service.extraPorts Extra ports to expose in openapi-merger service (normally used with the `sidecars` value)
+  ##
+  extraPorts: []
+  ## @param service.sessionAffinity Control where client requests go, to the same pod or round-robin
+  ## Values: ClientIP or None
+  ## ref: https://kubernetes.io/docs/user-guide/services/
+  ##
+  sessionAffinity: None
+  ## @param service.sessionAffinityConfig Additional settings for the sessionAffinity
+  ## sessionAffinityConfig:
+  ##   clientIP:
+  ##     timeoutSeconds: 300
+  ##
+  sessionAffinityConfig: {}
+
+## openapi-merger ingress parameters
+## ref: http://kubernetes.io/docs/user-guide/ingress/
+##
+ingress:
+  ## @param ingress.enabled Enable ingress record generation for openapi-merger
+  ##
+  enabled: true
+  ## @param ingress.apiVersion Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion: ""
+  ## @param ingress.hostname Default host for the ingress record
+  ##
+  hostname: ""
+  #hostname: openapi-merger.local
+  ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName: ""
+  ## @param ingress.paths [array] Default paths for the ingress record
+  ## e.g:
+  ## paths:
+  ##   - path: /
+  ##     pathType: Prefix
+  paths:
+    - path: /swagger
+      pathType: Prefix
+    - path: /api-docs
+      pathType: Prefix
+  ## @param ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+  ## Use this parameter to set the required annotations for cert-manager, see
+  ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+  ## e.g:
+  ## annotations:
+  ##   kubernetes.io/ingress.class: nginx
+  ##   cert-manager.io/cluster-issuer: cluster-issuer-name
+  ##
+  annotations: {}
+  ## @param ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Rely on cert-manager to create it by setting the corresponding annotations
+  ##   - Rely on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+  ##
+  tls: false
+  ## @param ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+  ##
+  selfSigned: false
+  ## @param ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
+  ## extraHosts:
+  ##   - name: openapi-merger.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## @param ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## @param ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - openapi-merger.local
+  ##   secretName: openapi-merger.local-tls
+  ##
+  extraTls: []
+  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: openapi-merger.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
+  ## @param ingress.extraRules Additional rules to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-rules
+  ## e.g:
+  ## extraRules:
+  ## - host: example.local
+  ##     http:
+  ##       path: /
+  ##       backend:
+  ##         service:
+  ##           name: example-svc
+  ##           port:
+  ##             name: http
+  ##
+  extraRules: []
+
+## @section cronJob parameters
+##
+cronjob:
+  ## @param cronjob.schedule Schedule in Cron format to save snapshots
+  ## See https://en.wikipedia.org/wiki/Cron
+  ##
+  schedule: "*/1 * * * *"
+  ## @param cronjob.historyLimit Number of successful finished jobs to retain
+  ##
+  historyLimit: 3
+  ## @param cronjob.podAnnotations [object] Pod annotations for cronjob pods
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  ##
+  podAnnotations: {}
+  ## Configure resource requests and limits for snapshotter containers
+  ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  ## We usually recommend not to specify default resources and to leave this as a conscious
+  ## choice for the user. This also increases chances charts run on environments with little
+  ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+  ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  ## @param cronjob.resources.limits [object] Cronjob container resource limits
+  ## @param cronjob.resources.requests [object] Cronjob container resource requests
+  ##
+  resources:
+    ## Example:
+    ## limits:
+    ##    cpu: 500m
+    ##    memory: 1Gi
+    ##
+    limits: {}
+    requests: {}
+  ## Digital Catapult openapi-merger cronjob init container image
+  ## ref: https://hub.docker.com/r/digicatapult/openapi-merger/tags/
+  ## @param cronjob.initImage.registry openapi-merger cronjob init container image registry
+  ## @param cronjob.initImage.repository openapi-merger cronjob container image repository
+  ## @param cronjob.initImage.tag openapi-merger cronjob container image tag (immutable tags are recommended)
+  ## @param cronjob.initImage.digest openapi-merger cronjob container image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param cronjob.initImage.pullPolicy openapi-merger ceonjob container image pull policy
+  ## @param cronjob.initImage.pullSecrets openapi-merger cronjob container image pull secrets
+  ## @param cronjob.initImage.debug Enable openapi-merger cronjob container image debug mode
+  ##
+  initImage:
+    registry: docker.io
+    repository: node
+    tag: hydrogen-alpine
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    ## Enable debug mode
+    ##
+    debug: false
+
+  ## Digital Catapult openapi-merger cronjob image
+  ## ref: https://hub.docker.com/r/digicatapult/openapi-merger/tags/
+  ## @param cronjob.image.registry openapi-merger cronjob image registry
+  ## @param cronjob.image.repository openapi-merger cronjob image repository
+  ## @param cronjob.image.tag openapi-merger cronjob image tag (immutable tags are recommended)
+  ## @param cronjob.image.digest openapi-merger cronjob image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param cronjob.image.pullPolicy openapi-merger ceonjob image pull policy
+  ## @param cronjob.image.pullSecrets openapi-merger cronjob image pull secrets
+  ## @param cronjob.image.debug Enable openapi-merger cronjob image debug mode
+  ##
+  image:
+    registry: docker.io
+    repository: curlimages/curl
+    tag: 7.87.0
+    digest: ""
+    ## Specify a imagePullPolicy
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ## e.g:
+    ## pullSecrets:
+    ##   - myRegistryKeySecretName
+    ##
+    pullSecrets: []
+    ## Enable debug mode
+    ##
+    debug: false
+
+  ## @param cronjob.nodeSelector Node labels for cronjob pods assignment
+  ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  ##
+  nodeSelector: {}
+  ## @param cronjob.tolerations Tolerations for cronjob pods assignment
+  ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+##
+## @section Other Parameters
+##
+
+## ServiceAccount configuration
+##
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
+  ##
+  create: true
+  ## @param serviceAccount.name The name of the ServiceAccount to use.
+  ## If not set and create is true, a name is generated using the common.names.fullname template
+  ##
+  name: ""
+  ## @param serviceAccount.annotations Additional Service Account annotations (evaluated as a template)
+  ##
+  annotations: {}
+  ## @param serviceAccount.automountServiceAccountToken Automount service account token for the server service account
+  ##
+  automountServiceAccountToken: true

--- a/charts/openapi-merger/values.yaml
+++ b/charts/openapi-merger/values.yaml
@@ -95,7 +95,7 @@ apiDocsMock:
   enabled: false
 ## @param security Enable JWT Bearer security configuration in the merged OpenAPI spec
 ##
-security: false
+security: true
 
 ## Digital Catapult openapi-merger image
 ## ref: https://hub.docker.com/r/digicatapult/openapi-merger/tags/
@@ -489,8 +489,7 @@ ingress:
   apiVersion: ""
   ## @param ingress.hostname Default host for the ingress record
   ##
-  hostname: ""
-  #hostname: openapi-merger.local
+  hostname: openapi-merger.local
   ## @param ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
   ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
   ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/

--- a/charts/wasp-open-api/Chart.yaml
+++ b/charts/wasp-open-api/Chart.yaml
@@ -32,4 +32,4 @@ maintainers:
 name: wasp-open-api
 sources:
   - https://github.com/digicatapult/wasp-open-api
-version: 1.2.0
+version: 1.2.1

--- a/charts/wasp-open-api/README.md
+++ b/charts/wasp-open-api/README.md
@@ -1,3 +1,5 @@
+# DEPRECATED USE openapi-merger instead
+This chart will no longer be maintained and the majority of functionality has been moved to `openapi-merger` chart as it is more generic than just something used in the WASP ecosystem.
 # wasp-open-api
 
 The wasp-open-api is a component of the WASP (Wide-Area-Sensor-Platform), an IoT platform designed to normalise and consolidate data from multiple IoT data services into one place. The wasp-open-api service creates a merged OpenAPI spec from several microservices and hosts a Swagger interface. See [https://github.com/digicatapult/wasp-documentation](https://github.com/digicatapult/wasp-documentation) for details.


### PR DESCRIPTION
Adds openapi-merger chart and deprecates the wasp-open-api chart