### PR TITLE
Remove extraSecuritySchemas debugging values

### DIFF
--- a/charts/openapi-merger/Chart.lock
+++ b/charts/openapi-merger/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 13.2.34
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.13.3
-digest: sha256:a902a7e31f1a274d8fee49c0471c1af1f1c27d905ecf5009e34ea8083409701f
-generated: "2023-11-13T08:46:58.74619Z"
+  version: 2.19.1
+digest: sha256:160f1fd1682d5e283f63be7430775faf68d1f28123930a28efec1f5d91b8aaeb
+generated: "2024-04-26T13:59:55.203997+01:00"

--- a/charts/openapi-merger/Chart.yaml
+++ b/charts/openapi-merger/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: openapi-merger
 sources:
   - https://github.com/digicatapult/openapi-merger
-version: 2.1.0
+version: 2.1.1

--- a/charts/openapi-merger/values.yaml
+++ b/charts/openapi-merger/values.yaml
@@ -156,11 +156,7 @@ securitySchema:
 ##     type: "bearer"
 ##     bearer:
 ##       format: "JWT"
-extraSecuritySchemas:
-  - name: oauth3
-    type: bearer
-    bearer:
-      format: JWT
+extraSecuritySchemas: []
 
 ## Digital Catapult openapi-merger image
 ## ref: https://hub.docker.com/r/digicatapult/openapi-merger/tags/


### PR DESCRIPTION
Removes debugging values from the `openapi-merger` helm chart that were eroneously left in after #91 
