### PR TITLE
veritable-ui - Added nodemailer params

### DIFF
--- a/charts/veritable-ui/Chart.lock
+++ b/charts/veritable-ui/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 15.3.5
+  version: 15.5.1
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.19.3
-digest: sha256:8c11bb55c15a366374ae80279fedbd9e7b788f446c04779c62f3b1ede3dc808e
-generated: "2024-05-21T12:30:29.531967+01:00"
+digest: sha256:13af80032ba7c0de5388ca3095a0cbff8bfa6e3f6401c7bb4a993751b832a857
+generated: "2024-06-03T12:54:22.275165+01:00"

--- a/charts/veritable-ui/Chart.yaml
+++ b/charts/veritable-ui/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: veritable
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: v0.3.14
+appVersion: v0.3.17
 dependencies:
   - condition: postgresql.enabled
     name: postgresql
@@ -24,4 +24,4 @@ maintainers:
 name: veritable-ui
 sources:
   - https://github.com/digicatapult/veritable-ui
-version: 1.0.1
+version: 1.0.2

--- a/charts/veritable-ui/README.md
+++ b/charts/veritable-ui/README.md
@@ -70,29 +70,37 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### veritable UI config parameters
 
-| Name                                    | Description                                             | Value                                                            |
-| --------------------------------------- | ------------------------------------------------------- | ---------------------------------------------------------------- |
-| `label`                                 | veritable-ui label                                      | `veritable ui`                                                   |
-| `companysHouseApiKey.enabled`           | Enable companys house secret                            | `true`                                                           |
-| `companysHouseApiKey.secret`            | veritable-ui secret value                               | `companysHouseApiKey`                                            |
-| `companysHouseApiKey.existingSecret`    | veritable-ui existing secret                            | `""`                                                             |
-| `companysHouseApiKey.existingSecretKey` | veritable-ui existing secret key                        | `""`                                                             |
-| `companysHouseApiUrl`                   | companys house api URL for retrieving company's details | `https://api.company-information.service.gov.uk`                 |
-| `logLevel`                              | veritable-ui logging level                              | `debug`                                                          |
-| `cookieSessionKeys.enabled`             | Enable cookies session keys secret                      | `true`                                                           |
-| `cookieSessionKeys.secret`              | veritable-ui secret vaapiSwaggerBgColorlue              | `["secret"]`                                                     |
-| `cookieSessionKeys.existingSecret`      | veritable-ui existing secret                            | `""`                                                             |
-| `cookieSessionKeys.existingSecretKey`   | veritable-ui existing secret key                        | `""`                                                             |
-| `publicUrl`                             | veritable-ui external URL                               | `http://localhost:3080`                                          |
-| `apiSwaggerBgColor`                     | veritable-ui swagger ackground color                    | `#fafafa`                                                        |
-| `apiSwaggerTitle`                       | veritable-ui swagger title                              | `Veritable`                                                      |
-| `apiSwaggerHeading`                     | veritable-ui swagger heading                            | `Veritable`                                                      |
-| `idpClientId`                           | veritable-ui                                            | `veritable-ui`                                                   |
-| `idpPublicURLPrefix`                    | veritable-ui public realm                               | `http://localhost:3080/realms/veritable/protocol/openid-connect` |
-| `idpInternalURLPrefix`                  | veritable-ui private/internal realm                     | `http://localhost:3080/realms/veritable/protocol/openid-connect` |
-| `idpAuthPath`                           | veritable-ui IDP authentication path                    | `/auth`                                                          |
-| `idpTokenPath`                          | veritable-ui IDP token path                             | `/token`                                                         |
-| `idpJWKSPath`                           | veritable-ui IDP certs path                             | `/certs`                                                         |
+| Name                                    | Description                                                    | Value                                                            |
+| --------------------------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `label`                                 | veritable-ui label                                             | `veritable ui`                                                   |
+| `companysHouseApiKey.enabled`           | Enable companys house secret                                   | `true`                                                           |
+| `companysHouseApiKey.secret`            | veritable-ui secret value                                      | `companysHouseApiKey`                                            |
+| `companysHouseApiKey.existingSecret`    | veritable-ui existing secret                                   | `""`                                                             |
+| `companysHouseApiKey.existingSecretKey` | veritable-ui existing secret key                               | `""`                                                             |
+| `companysHouseApiUrl`                   | companys house api URL for retrieving company's details        | `https://api.company-information.service.gov.uk`                 |
+| `logLevel`                              | veritable-ui logging level                                     | `debug`                                                          |
+| `cookieSessionKeys.enabled`             | Enable cookies session keys secret                             | `true`                                                           |
+| `cookieSessionKeys.secret`              | veritable-ui secret vaapiSwaggerBgColorlue                     | `["secret"]`                                                     |
+| `cookieSessionKeys.existingSecret`      | veritable-ui existing secret                                   | `""`                                                             |
+| `cookieSessionKeys.existingSecretKey`   | veritable-ui existing secret key                               | `""`                                                             |
+| `publicUrl`                             | veritable-ui external URL                                      | `http://localhost:3080`                                          |
+| `apiSwaggerBgColor`                     | veritable-ui swagger ackground color                           | `#fafafa`                                                        |
+| `apiSwaggerTitle`                       | veritable-ui swagger title                                     | `Veritable`                                                      |
+| `apiSwaggerHeading`                     | veritable-ui swagger heading                                   | `Veritable`                                                      |
+| `idpClientId`                           | veritable-ui                                                   | `veritable-ui`                                                   |
+| `idpPublicURLPrefix`                    | veritable-ui public realm                                      | `http://localhost:3080/realms/veritable/protocol/openid-connect` |
+| `idpInternalURLPrefix`                  | veritable-ui private/internal realm                            | `http://localhost:3080/realms/veritable/protocol/openid-connect` |
+| `idpAuthPath`                           | veritable-ui IDP authentication path                           | `/auth`                                                          |
+| `idpTokenPath`                          | veritable-ui IDP token path                                    | `/token`                                                         |
+| `idpJWKSPath`                           | veritable-ui IDP certs path                                    | `/certs`                                                         |
+| `emailTransport`                        | The email transport method to use, current options only STREAM | `STREAM`                                                         |
+| `emailFromAddress`                      | veritable-ui email from address                                | `hello@veritable.com`                                            |
+| `emailAdminAddress`                     | veritable-ui email admin address                               | `admin@veritable.com`                                            |
+| `cloudagentAdminOrigin`                 | veritable-ui cloudagent admin origin URL                       | `http://localhost:3080`                                          |
+| `invitationPin.enabled`                 | Enable Invitation pin secret                                   | `true`                                                           |
+| `invitationPin.secret`                  | the secret value                                               | `""`                                                             |
+| `invitationPin.existingSecret`          | If there is an existing secret for the invitationPin           | `""`                                                             |
+| `invitationPin.existingSecretKey`       | the key to use within the existing secret                      | `""`                                                             |
 
 ### veritable-ui deployment parameters
 
@@ -100,7 +108,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | `image.registry`                                  | veritable-ui image registry                                                                                                                             | `docker.io`                 |
 | `image.repository`                                | veritable-ui image repository                                                                                                                           | `digicatapult/veritable-ui` |
-| `image.tag`                                       | veritable-ui image tag (immutable tags are recommended)                                                                                                 | `v0.3.14`                   |
+| `image.tag`                                       | veritable-ui image tag (immutable tags are recommended)                                                                                                 | `v0.3.17`                   |
 | `image.digest`                                    | veritable-ui image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                        |
 | `image.pullPolicy`                                | veritable-ui image pull policy                                                                                                                          | `IfNotPresent`              |
 | `image.pullSecrets`                               | veritable-ui image pull secrets                                                                                                                         | `[]`                        |
@@ -206,21 +214,21 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### Init Container Parameters
 
-| Name                                          | Description                                                                                                                                                     | Value                                                        |
-| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `initDbCreate.image.registry`                 | sqnc-routing-service image registry                                                                                                                             | `docker.io`                                                  |
-| `initDbCreate.image.repository`               | sqnc-routing-service image repository                                                                                                                           | `postgres`                                                   |
-| `initDbCreate.image.tag`                      | sqnc-routing-service image tag (immutable tags are recommended)                                                                                                 | `16-alpine`                                                  |
-| `initDbCreate.image.digest`                   | sqnc-routing-service image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                                                         |
-| `initDbCreate.image.pullPolicy`               | sqnc-routing-service image pull policy                                                                                                                          | `IfNotPresent`                                               |
-| `initDbCreate.image.pullSecrets`              | sqnc-routing-service image pull secrets                                                                                                                         | `[]`                                                         |
-| `initDbMigrate.enable`                        | Run database migration in an init container                                                                                                                     | `true`                                                       |
-| `initDbMigrate.environment`                   | Database configuration environment to run database into                                                                                                         | `production`                                                 |
-| `initDbMigrate.args`                          | Argument to pass to knex to migrate the database                                                                                                                | `["migrate:latest","--knexfile","build/lib/db/knexfile.js"]` |
-| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                                                            | `true`                                                       |
-| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                                                                          | `""`                                                         |
-| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template)                                                                                                | `{}`                                                         |
-| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                                                                  | `true`                                                       |
+| Name                                          | Description                                                                                                                                         | Value                                                           |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `initDbCreate.image.registry`                 | Postgres image registry                                                                                                                             | `docker.io`                                                     |
+| `initDbCreate.image.repository`               | postgres image repository                                                                                                                           | `postgres`                                                      |
+| `initDbCreate.image.tag`                      | postgres image tag (immutable tags are recommended)                                                                                                 | `16-alpine`                                                     |
+| `initDbCreate.image.digest`                   | postgres image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                                                            |
+| `initDbCreate.image.pullPolicy`               | postgres image pull policy                                                                                                                          | `IfNotPresent`                                                  |
+| `initDbCreate.image.pullSecrets`              | postgres image pull secrets                                                                                                                         | `[]`                                                            |
+| `initDbMigrate.enable`                        | Run database migration in an init container                                                                                                         | `true`                                                          |
+| `initDbMigrate.environment`                   | Database configuration environment to run database into                                                                                             | `production`                                                    |
+| `initDbMigrate.args`                          | Argument to pass to knex to migrate the database                                                                                                    | `["migrate:latest","--knexfile","build/models/db/knexfile.js"]` |
+| `serviceAccount.create`                       | Specifies whether a ServiceAccount should be created                                                                                                | `true`                                                          |
+| `serviceAccount.name`                         | The name of the ServiceAccount to use.                                                                                                              | `""`                                                            |
+| `serviceAccount.annotations`                  | Additional Service Account annotations (evaluated as a template)                                                                                    | `{}`                                                            |
+| `serviceAccount.automountServiceAccountToken` | Automount service account token for the server service account                                                                                      | `true`                                                          |
 
 ### Database Parameters
 

--- a/charts/veritable-ui/ci/ct-values.yaml
+++ b/charts/veritable-ui/ci/ct-values.yaml
@@ -1,0 +1,2 @@
+invitationPin:
+  secret: blah

--- a/charts/veritable-ui/templates/_helpers.tpl
+++ b/charts/veritable-ui/templates/_helpers.tpl
@@ -309,19 +309,19 @@ veritable-ui:
 {{/* Validate if the value of a secret is being set, if it is not, the existing secret must be set instead*/}}
 {{- define "veritable-ui.validateSecretValues" -}}
 {{- if not .Values.cookieSessionKeys.existingSecret -}}
-{{- if not .Values.cookieSessionKeys.value -}}
+{{- if not .Values.cookieSessionKeys.secret -}}
 veritable-ui:
     If a secret is not being used for the cookie session keys, a value must be provided
 {{- end -}}
 {{- end -}}
 {{- if not .Values.invitationPin.existingSecret -}}
-{{- if not .Values.invitationPin.value -}}
+{{- if not .Values.invitationPin.secret -}}
 veritable-ui:
     If a secret is not being used for the invitation pin, a value must be provided
 {{- end -}}
 {{- end -}}
 {{- if not .Values.companysHouseApiKey.existingSecret -}}
-{{- if not .Values.companysHouseApiKey.value -}}
+{{- if not .Values.companysHouseApiKey.secret -}}
 veritable-ui:
     If a secret is not being used for the company house api key, a value must be provided
 {{- end -}}

--- a/charts/veritable-ui/templates/_helpers.tpl
+++ b/charts/veritable-ui/templates/_helpers.tpl
@@ -252,6 +252,8 @@ Compile all warnings into a single message, and call fail.
 {{- $messages := list -}}
 {{- $messages := append $messages (include "veritable-ui.validateValues.databaseName" .) -}}
 {{- $messages := append $messages (include "veritable-ui.validateValues.databaseUser" .) -}}
+{{- $messages := append $messages (include "veritable-ui.validateSecretKeys" .) -}}
+{{- $messages := append $messages (include "veritable-ui.validateSecretValues" .) -}}
 {{- $messages := without $messages "" -}}
 {{- $message := join "\n" $messages -}}
 
@@ -278,6 +280,50 @@ veritable-ui:
 {{- if not (regexMatch "^[a-zA-Z_]+$" $db_user) -}}
 veritable-ui:
     When creating a database the username must consist of the characters a-z, A-Z and _ only
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate if secret keys are being set or if a pre-existing secret is being used*/}}
+{{- define "veritable-ui.validateSecretKeys" -}}
+{{- if .Values.cookieSessionKeys.existingSecret -}}
+{{- if not .Values.cookieSessionKeys.existingSecretKey -}}
+veritable-ui:
+    If an existing secret is being used for the cookie session keys, a key must be provided
+{{- end -}}
+{{- end -}}
+{{- if .Values.invitationPin.existingSecret -}}
+{{- if not .Values.invitationPin.existingSecretKey -}}
+veritable-ui:
+    If an existing secret is being used for the invitation pin, a key must be provided
+{{- end -}}
+{{- end -}}
+{{- if .Values.companysHouseApiKey.existingSecret -}}
+{{- if not .Values.companysHouseApiKey.existingSecretKey -}}
+veritable-ui:
+    If an existing secret is being used for the company house api key, a key must be provided
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validate if the value of a secret is being set, if it is not, the existing secret must be set instead*/}}
+{{- define "veritable-ui.validateSecretValues" -}}
+{{- if not .Values.cookieSessionKeys.existingSecret -}}
+{{- if not .Values.cookieSessionKeys.value -}}
+veritable-ui:
+    If a secret is not being used for the cookie session keys, a value must be provided
+{{- end -}}
+{{- end -}}
+{{- if not .Values.invitationPin.existingSecret -}}
+{{- if not .Values.invitationPin.value -}}
+veritable-ui:
+    If a secret is not being used for the invitation pin, a value must be provided
+{{- end -}}
+{{- end -}}
+{{- if not .Values.companysHouseApiKey.existingSecret -}}
+{{- if not .Values.companysHouseApiKey.value -}}
+veritable-ui:
+    If a secret is not being used for the company house api key, a value must be provided
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/veritable-ui/templates/_helpers.tpl
+++ b/charts/veritable-ui/templates/_helpers.tpl
@@ -61,6 +61,35 @@ Add environment variables to configure cookie session keys
 {{- end -}}
 {{- end -}}
 
+{{/*
+Create a default fully qualified app name for the session cookies.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "veritable-ui.invitationPin.fullname" -}}
+{{- printf "%s-invitation-pin" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-"  -}}
+{{- end -}}
+
+{{/*
+Return the invitation pin Secret Name
+*/}}
+{{- define "veritable-ui.invitationPinSecretName" -}}
+{{- if .Values.invitationPin.existingSecret -}}
+    {{- tpl .Values.invitationPin.existingSecret $ -}}
+{{- else -}}
+    {{- include "veritable-ui.invitationPin.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add environment variables to configure invitation pin keys 
+*/}}
+{{- define "veritable-ui.invitationPinSecretKey" -}}
+{{- if .Values.invitationPin.existingSecretKey -}}
+    {{- printf "%s" .Values.invitationPin.existingSecretKey -}}
+{{- else -}}
+    {{- print "pin" -}}
+{{- end -}}
+{{- end -}}
 
 {{/*
 Create a default fully qualified app name for the company house.

--- a/charts/veritable-ui/templates/deployment.yaml
+++ b/charts/veritable-ui/templates/deployment.yaml
@@ -207,6 +207,19 @@ spec:
                 secretKeyRef:
                   name: {{ include "veritable-ui.databaseSecretName" . }}
                   key: {{ include "veritable-ui.databaseSecretPasswordKey" . }}
+            - name: EMAIL_TRANSPORT
+              value: {{ .Values.emailTransport | quote }}
+            - name: EMAIL_FROM_ADDRESS
+              value: {{ .Values.emailFromAddress | quote }}
+            - name: EMAIL_ADMIN_ADDRESS
+              value: {{ .Values.emailAdminAddress | quote }}
+            - name: CLOUDAGENT_ADMIN_ORIGIN
+              value: {{ .Values.cloudagentAdminOrigin | quote }}
+            - name: INVITATION_PIN_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "veritable-ui.invitationPinSecretName" . }}
+                  key: {{ include "veritable-ui.invitationPinSecretKey" . }}
             {{- if .Values.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/veritable-ui/templates/secret-invitation-pin.yaml
+++ b/charts/veritable-ui/templates/secret-invitation-pin.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.invitationPin.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-invitation-pin" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: veritable-ui
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  pin: {{ tpl "{{ .Values.invitationPin.secret | toYaml }}" . | b64enc | quote }}
+{{- end }}

--- a/charts/veritable-ui/values.yaml
+++ b/charts/veritable-ui/values.yaml
@@ -107,6 +107,23 @@ idpAuthPath: "/auth"
 idpTokenPath: "/token"
 ## @param idpJWKSPath veritable-ui IDP certs path
 idpJWKSPath: "/certs"
+## @param emailTransport The email transport method to use, current options only STREAM
+emailTransport: "STREAM"
+## @param emailFromAddress veritable-ui email from address
+emailFromAddress: "hello@veritable.com"
+## @param emailAdminAddress veritable-ui email admin address
+emailAdminAddress: "admin@veritable.com"
+## @param cloudagentAdminOrigin veritable-ui cloudagent admin origin URL
+cloudagentAdminOrigin: "http://localhost:3080"
+## @param invitationPin.enabled Enable Invitation pin secret
+## @param invitationPin.secret the secret value
+## @param invitationPin.existingSecret If there is an existing secret for the invitationPin
+## @param invitationPin.existingSecretKey the key to use within the existing secret
+invitationPin:
+  enabled: true
+  secret: ""
+  existingSecret: ""
+  existingSecretKey: ""
 ## @section veritable-ui deployment parameters
 ## Digital Catapult veritable-ui image
 ## ref: https://hub.docker.com/r/digicatapult/veritable-ui/tags/
@@ -121,7 +138,7 @@ idpJWKSPath: "/certs"
 image:
   registry: docker.io
   repository: digicatapult/veritable-ui
-  tag: v0.3.14
+  tag: v0.3.17
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -559,12 +576,12 @@ ingress:
 initDbCreate:
   ## PostreSQL image
   ## ref: https://hub.docker.com/_/postgres/tags/
-  ## @param initDbCreate.image.registry sqnc-routing-service image registry
-  ## @param initDbCreate.image.repository sqnc-routing-service image repository
-  ## @param initDbCreate.image.tag sqnc-routing-service image tag (immutable tags are recommended)
-  ## @param initDbCreate.image.digest sqnc-routing-service image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
-  ## @param initDbCreate.image.pullPolicy sqnc-routing-service image pull policy
-  ## @param initDbCreate.image.pullSecrets sqnc-routing-service image pull secrets
+  ## @param initDbCreate.image.registry Postgres image registry
+  ## @param initDbCreate.image.repository postgres image repository
+  ## @param initDbCreate.image.tag postgres image tag (immutable tags are recommended)
+  ## @param initDbCreate.image.digest postgres image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended)
+  ## @param initDbCreate.image.pullPolicy postgres image pull policy
+  ## @param initDbCreate.image.pullSecrets postgres image pull secrets
   ##
   image:
     registry: docker.io


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.


- [X] Feature

## Linked tickets

https://digicatapult.atlassian.net/browse/VR-113

## High level description

Adds nodemailer params to the helm chart

## Detailed description

Adds additional parameters to the deployment, adds an additional secret for the nodemailer PIN, Updates the image used.


## Describe alternatives you've considered

N/A

## Operational impact

Before upgrading to the newest instance of the chart we will need to ensure the new parameters are added (defaults exist except for the secret).

## Additional context

N/A