### PR TITLE
Update veritable-ui image and add cloudagentAdminWsOrigin env var

### DIFF
--- a/charts/veritable-ui/Chart.yaml
+++ b/charts/veritable-ui/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   category: veritable
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: v0.4.0
+appVersion: v0.5.0
 dependencies:
   - condition: postgresql.enabled
     name: postgresql
@@ -18,10 +18,10 @@ home: https://github.com/digicatapult/veritable-ui
 keywords:
   - veritable
 maintainers:
-  - name: digicatapult  # Digital Catapult
+  - name: digicatapult # Digital Catapult
     url: https://github.com/digicatapult/helm-charts
     email: opensource@digicatapult.org.uk
 name: veritable-ui
 sources:
   - https://github.com/digicatapult/veritable-ui
-version: 1.0.3
+version: 1.0.4

--- a/charts/veritable-ui/Chart.yaml
+++ b/charts/veritable-ui/Chart.yaml
@@ -18,7 +18,7 @@ home: https://github.com/digicatapult/veritable-ui
 keywords:
   - veritable
 maintainers:
-  - name: digicatapult # Digital Catapult
+  - name: digicatapult  # Digital Catapult
     url: https://github.com/digicatapult/helm-charts
     email: opensource@digicatapult.org.uk
 name: veritable-ui

--- a/charts/veritable-ui/README.md
+++ b/charts/veritable-ui/README.md
@@ -97,6 +97,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `emailFromAddress`                      | veritable-ui email from address                                | `hello@veritable.com`                                            |
 | `emailAdminAddress`                     | veritable-ui email admin address                               | `admin@veritable.com`                                            |
 | `cloudagentAdminOrigin`                 | veritable-ui cloudagent admin origin URL                       | `http://localhost:3080`                                          |
+| `cloudagentAdminWsOrigin`               | veritable-ui cloudagent admin origin websocket URL             | `ws://localhost:3080`                                            |
 | `invitationFromCompanyNumber`           | Companies House number to claim created invitations are from   | `00000000`                                                       |
 | `invitationPin.enabled`                 | Enable Invitation pin secret                                   | `true`                                                           |
 | `invitationPin.secret`                  | the secret value                                               | `""`                                                             |
@@ -109,7 +110,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
 | `image.registry`                                  | veritable-ui image registry                                                                                                                             | `docker.io`                 |
 | `image.repository`                                | veritable-ui image repository                                                                                                                           | `digicatapult/veritable-ui` |
-| `image.tag`                                       | veritable-ui image tag (immutable tags are recommended)                                                                                                 | `v0.4.0`                    |
+| `image.tag`                                       | veritable-ui image tag (immutable tags are recommended)                                                                                                 | `v0.5.0`                    |
 | `image.digest`                                    | veritable-ui image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                        |
 | `image.pullPolicy`                                | veritable-ui image pull policy                                                                                                                          | `IfNotPresent`              |
 | `image.pullSecrets`                               | veritable-ui image pull secrets                                                                                                                         | `[]`                        |

--- a/charts/veritable-ui/templates/deployment.yaml
+++ b/charts/veritable-ui/templates/deployment.yaml
@@ -215,6 +215,8 @@ spec:
               value: {{ .Values.emailAdminAddress | quote }}
             - name: CLOUDAGENT_ADMIN_ORIGIN
               value: {{ .Values.cloudagentAdminOrigin | quote }}
+            - name: CLOUDAGENT_ADMIN_WS_ORIGIN
+              value: {{ .Values.cloudagentAdminWsOrigin | quote }}
             - name: INVITATION_FROM_COMPANY_NUMBER  
               value: {{ .Values.invitationFromCompanyNumber | quote }}
             - name: INVITATION_PIN_SECRET

--- a/charts/veritable-ui/values.yaml
+++ b/charts/veritable-ui/values.yaml
@@ -115,6 +115,8 @@ emailFromAddress: "hello@veritable.com"
 emailAdminAddress: "admin@veritable.com"
 ## @param cloudagentAdminOrigin veritable-ui cloudagent admin origin URL
 cloudagentAdminOrigin: "http://localhost:3080"
+## @param cloudagentAdminWsOrigin veritable-ui cloudagent admin origin websocket URL
+cloudagentAdminWsOrigin: "ws://localhost:3080"
 ## @param invitationFromCompanyNumber Companies House number to claim created invitations are from
 invitationFromCompanyNumber: "00000000"
 ## @param invitationPin.enabled Enable Invitation pin secret
@@ -140,7 +142,7 @@ invitationPin:
 image:
   registry: docker.io
   repository: digicatapult/veritable-ui
-  tag: v0.4.0
+  tag: v0.5.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

[VR-132](https://digicatapult.atlassian.net/browse/VR-132)

## High level description

Update veritable-ui to v0.5.0

## Detailed description

Updates image and adds new config value `cloudagentAdminWsOrigin`

## Describe alternatives you've considered

N/A

## Operational impact

None

## Additional context

N/A


[VR-132]: https://digicatapult.atlassian.net/browse/VR-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ