### PR TITLE
Adding self-hosted renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,35 @@
+name: Renovate
+
+on:
+  schedule:
+    # Runs every hour
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - 'renovate.config.js'
+      - '.github/workflows/renovate.yml'
+      - 'scripts/**'
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get GitHub App Token
+        id: get_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Run Self-hosted Renovate
+        uses: renovatebot/github-action@v40.2.4
+        with:
+          token: ${{ steps.get_token.outputs.token }}
+          configurationFile: renovate.config.js
+        env:
+          LOG_LEVEL: debug

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     # Runs every hour
     - cron: '0 * * * *'
+  repository_dispatch:
+    types:
+      - renovate
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -7,7 +7,92 @@ A collection of [helm](https://helm.sh) charts created by [Digital Catapult](htt
 * [openapi-merger](charts/openapi-merger/README.md) - Deploy the openapi-merger
 * [sqnc-identity-service](charts/sqnc-identity-service/README.md) - Deploy sqnc-identity-service
 * [sqnc-ipfs](charts/sqnc-ipfs/README.md) - Deploy sqnc-ipfs
-* [sqnc-matchmaker-api](charts/sqnc-matchmacker-api/README.md) - Deploy sqnc-matchmaker-api service
+* [sqnc-matchmaker-api](charts/sqnc-matchmaker-api/README.md) - Deploy sqnc-matchmaker-api service
 * [sqnc-node](charts/sqnc-node/README.md) - Deploy sqnc-node
 * [veritable-cloudagent](charts/veritable-cloudagent/README.md) - Deploy the veritable-cloudagent
 * [veritable-ui](charts/veritable-ui/README.md) - Deploy the veritable-ui
+
+---
+
+## Renovate Setup
+
+This repository uses [Renovate](https://renovatebot.com/) to automate dependency updates for the Helm charts and GitHub Actions workflows.
+
+### Overview
+
+The self-hosted Renovate bot is configured to:
+
+- Update Helm chart dependencies individually.
+- Update `appVersion` in `Chart.yaml` files.
+- Run a script to bump the chart version after updates.
+- Update GitHub Actions workflows.
+- Automerge patch updates for dependencies and workflows.
+- Only run in self-hosted mode and not via the Renovate GitHub App.
+- Disable Renovate onboarding.
+
+### GitHub App Setup
+
+To authenticate the self-hosted Renovate bot, a GitHub App is used. Follow these steps to set up the GitHub App and obtain the `APP_ID` and `PRIVATE_KEY` secrets:
+
+#### 1. Create a GitHub App
+
+- **Navigate to GitHub Developer Settings:**
+  - Go to [GitHub Developer Settings](https://github.com/organizations/digicatapult/settings/apps/) for the Digicatapult Org.
+- **Create a New GitHub App:**
+  - Click on **"New GitHub App"**.
+- **Configure the GitHub App:**
+  - **App Name:** Choose a unique name, e.g., `self-hosted-renovate-bot`.
+  - **Homepage URL:** Enter your repository URL or `https://github.com/digicatapult/helm-charts`.
+  - **Callback URL:** Leave empty.
+  - **Webhook URL and Secret:** Leave empty.
+  - **Permissions:**
+    - **Repository Permissions:** as per the [Renovate Documentation](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app).
+- **Save the GitHub App:**
+  - Click **"Create GitHub App"**.
+
+#### 2. Generate a Private Key
+
+- **Generate Private Key:**
+  - On the GitHub App page, scroll to **"Private keys"**.
+  - Click **"Generate a private key"**.
+  - A `.pem` file will be downloaded. This is your `PRIVATE_KEY`.
+- **Copy the Private Key:**
+  - Open the `.pem` file in a text editor.
+  - Copy the entire contents, including the `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines.
+
+#### 3. Obtain the App ID
+
+- **Find the App ID:**
+  - On the GitHub App page, note the **"App ID"** displayed near the top.
+  - This number is your `APP_ID`.
+
+#### 4. Install the GitHub App on Your Repository
+
+- **Install the App:**
+  - On the GitHub App page, click **"Install App"**.
+  - Select the repository you want to use with Renovate.
+  - Click **"Install"**.
+
+#### 5. Add Secrets to Your Repository
+
+- **Navigate to Repository Settings:**
+  - Go to your repository on GitHub.
+  - Click on the **"Settings"** tab.
+- **Add Secrets:**
+  - In the sidebar, click **"Secrets and variables"** > **"Actions"**.
+  - Click **"New repository secret"**.
+- **Add `APP_ID` Secret:**
+  - **Name:** `APP_ID`
+  - **Value:** Paste the `APP_ID` number.
+- **Add `PRIVATE_KEY` Secret:**
+  - **Name:** `PRIVATE_KEY`
+  - **Value:** Paste the contents of the `.pem` file.
+
+#### 6. Verify the Setup
+
+- **Trigger the Workflow:**
+  - Manually trigger the Renovate workflow or wait for it to run on schedule.
+- **Check the Workflow Run:**
+  - Ensure the **"Get GitHub App Token"** step completes successfully.
+- **Monitor Renovate:**
+  - Check that Renovate runs without authentication errors and processes updates as expected.

--- a/README.md
+++ b/README.md
@@ -32,67 +32,7 @@ The self-hosted Renovate bot is configured to:
 
 ### GitHub App Setup
 
-To authenticate the self-hosted Renovate bot, a GitHub App is used. Follow these steps to set up the GitHub App and obtain the `APP_ID` and `PRIVATE_KEY` secrets:
+To authenticate the self-hosted Renovate bot, a GitHub App is used. Follow [these steps](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app) to set up the [GitHub App](https://github.com/organizations/digicatapult/settings/apps/) and obtain the `APP_ID` and `PRIVATE_KEY` secrets:
 
-#### 1. Create a GitHub App
-
-- **Navigate to GitHub Developer Settings:**
-  - Go to [GitHub Developer Settings](https://github.com/organizations/digicatapult/settings/apps/) for the Digicatapult Org.
-- **Create a New GitHub App:**
-  - Click on **"New GitHub App"**.
-- **Configure the GitHub App:**
-  - **App Name:** Choose a unique name, e.g., `self-hosted-renovate-bot`.
-  - **Homepage URL:** Enter your repository URL or `https://github.com/digicatapult/helm-charts`.
-  - **Callback URL:** Leave empty.
-  - **Webhook URL and Secret:** Leave empty.
-  - **Permissions:**
-    - **Repository Permissions:** as per the [Renovate Documentation](https://docs.renovatebot.com/modules/platform/github/#running-as-a-github-app).
-- **Save the GitHub App:**
-  - Click **"Create GitHub App"**.
-
-#### 2. Generate a Private Key
-
-- **Generate Private Key:**
-  - On the GitHub App page, scroll to **"Private keys"**.
-  - Click **"Generate a private key"**.
-  - A `.pem` file will be downloaded. This is your `PRIVATE_KEY`.
-- **Copy the Private Key:**
-  - Open the `.pem` file in a text editor.
-  - Copy the entire contents, including the `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` lines.
-
-#### 3. Obtain the App ID
-
-- **Find the App ID:**
-  - On the GitHub App page, note the **"App ID"** displayed near the top.
-  - This number is your `APP_ID`.
-
-#### 4. Install the GitHub App on Your Repository
-
-- **Install the App:**
-  - On the GitHub App page, click **"Install App"**.
-  - Select the repository you want to use with Renovate.
-  - Click **"Install"**.
-
-#### 5. Add Secrets to Your Repository
-
-- **Navigate to Repository Settings:**
-  - Go to your repository on GitHub.
-  - Click on the **"Settings"** tab.
-- **Add Secrets:**
-  - In the sidebar, click **"Secrets and variables"** > **"Actions"**.
-  - Click **"New repository secret"**.
-- **Add `APP_ID` Secret:**
-  - **Name:** `APP_ID`
-  - **Value:** Paste the `APP_ID` number.
-- **Add `PRIVATE_KEY` Secret:**
-  - **Name:** `PRIVATE_KEY`
-  - **Value:** Paste the contents of the `.pem` file.
-
-#### 6. Verify the Setup
-
-- **Trigger the Workflow:**
-  - Manually trigger the Renovate workflow or wait for it to run on schedule.
-- **Check the Workflow Run:**
-  - Ensure the **"Get GitHub App Token"** step completes successfully.
-- **Monitor Renovate:**
-  - Check that Renovate runs without authentication errors and processes updates as expected.
+### Triggering the Workflow
+  You can manually trigger the Renovate workflow, wait for it to run on schedule or have it run via [respository_dispatch event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#repository_dispatch) using `renovate` as the event type.

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -1,0 +1,57 @@
+module.exports = (config) => {
+	if (!config.isSelfHosted) {
+	  console.log('Renovate is disabled when running via GitHub App.');
+	  return {
+		enabled: false,
+		onboarding: false,
+	  };
+	}
+  
+	console.log('Renovate is running in self-hosted mode.');
+  
+	return {
+	  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+	  onboarding: false,
+	  customManagers: [
+		{
+		  customType: 'regex',
+		  datasourceTemplate: 'docker',
+		  fileMatch: ['(^|/)Chart\\.yaml$'],
+		  matchStrings: [
+			'#\\s*renovate: image=(?<depName>.*?)\\s+appVersion:\\s*[\'"]?(?<currentValue>[\\w+\\.\\-]*)',
+		  ],
+		},
+	  ],
+	  packageRules: [
+		{
+		  description:
+			'Always bump chart version by a patch when updating values files.',
+		  matchManagers: ['helm-values', 'regex'],
+		  postUpgradeTasks: {
+			commands: ["scripts/bump-chart-version.sh '{{{parentDir}}}'"],
+			fileFilters: ['**/Chart.yaml'],
+			executionMode: 'branch',
+		  },
+		},
+		{
+		  matchManagers: ['helm-values', 'regex'],
+		  matchUpdateTypes: ['patch'],
+		  automerge: true,
+		  automergeType: 'pr',
+		  labels: ['automerge'],
+		},
+		{
+		  matchManagers: ['helm-values', 'regex'],
+		  matchUpdateTypes: ['minor', 'major'],
+		  automerge: false,
+		},
+		{
+		  matchManagers: ['github-actions'],
+		  matchUpdateTypes: ['patch'],
+		  automerge: true,
+		  labels: ['automerge'],
+		},
+	  ],
+	};
+  };
+  

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"github>digicatapult/renovate-config:helm"
-	]
-}

--- a/scripts/bump-chart-version.sh
+++ b/scripts/bump-chart-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+parent_dir="$1"
+
+chart_file="charts/${parent_dir}/Chart.yaml"
+
+if [[ ! -f "$chart_file" ]]; then
+  echo "Chart file not found: $chart_file"
+  exit 1
+fi
+
+version=$(grep "^version:" "$chart_file" | awk '{print $2}')
+if [[ -z "$version" ]]; then
+  echo "No valid version was found in $chart_file"
+  exit 1
+fi
+
+IFS='.' read -r major minor patch <<< "$version"
+
+# Always increment the patch version
+patch=$((patch + 1))
+
+new_version="${major}.${minor}.${patch}"
+echo -e "\nBumping version for $parent_dir from $version to $new_version"
+
+sed -i "s/^version:.*/version: ${new_version}/g" "$chart_file"


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature
- [X] Documentation Update
- [X] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

ENG-101

## High level description

Adds a self hosted renovate bot

## Detailed description

Adds a Github App with permissions for the RenovateBot to use.
Adds a workflow to run the renovateBot
Adds a script for bumping the chart version when an image increments
Renovate Config which disables the hosted renovateBot
Renovate Config for executing self-hosted runs


## Describe alternatives you've considered

N/A

## Operational impact

Will disable the existing renovateBots PRs

## Additional context

N/A
