### PR TITLE
Moved cloudagent to being a statefulset

### DIFF
--- a/charts/veritable-cloudagent/Chart.yaml
+++ b/charts/veritable-cloudagent/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   licenses: Apache-2.0
 apiVersion: v2
 # renovate: image=digicatapult/veritable-cloudagent
-appVersion: v0.10.25
+appVersion: v0.10.27
 dependencies:
   - condition: postgresql.enabled
     name: postgresql
@@ -26,4 +26,4 @@ maintainers:
 name: veritable-cloudagent
 sources:
   - https://github.com/digicatapult/veritable-cloudagent
-version: 1.0.8
+version: 2.0.0

--- a/charts/veritable-cloudagent/README.md
+++ b/charts/veritable-cloudagent/README.md
@@ -104,34 +104,40 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ### IPFS Container Parameters
 
-| Name                                      | Description                                                                                                                                     | Value          |
-| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| `ipfs.enabled`                            | Enable IPFS container within pod                                                                                                                | `true`         |
-| `ipfs.image.registry`                     | IPFS image registry                                                                                                                             | `docker.io`    |
-| `ipfs.image.repository`                   | IPFS image repository                                                                                                                           | `ipfs/kubo`    |
-| `ipfs.image.tag`                          | IPFS image tag (immutable tags are recommended)                                                                                                 | `v0.28.0`      |
-| `ipfs.image.digest`                       | IPFS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`           |
-| `ipfs.image.pullPolicy`                   | IPFS image pull policy                                                                                                                          | `IfNotPresent` |
-| `ipfs.containerPorts.api`                 | IPFS container API port                                                                                                                         | `5001`         |
-| `ipfs.resources.limits.cpu`               | The resources limits for the IPFS container for CPU                                                                                             | `500m`         |
-| `ipfs.resources.limits.memory`            | The resources limits for the IPFS container for memory                                                                                          | `512Mi`        |
-| `ipfs.resources.requests.cpu`             | The requested resources for the IPFS container for CPU                                                                                          | `250m`         |
-| `ipfs.resources.requests.memory`          | The requested resources for the IPFS container for memory                                                                                       | `256Mi`        |
-| `ipfs.livenessProbe.enabled`              | Enable livenessProbe on IPFS container                                                                                                          | `true`         |
-| `ipfs.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                         | `30`           |
-| `ipfs.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                                | `10`           |
-| `ipfs.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                               | `5`            |
-| `ipfs.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                             | `3`            |
-| `ipfs.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                             | `1`            |
-| `ipfs.readinessProbe.enabled`             | Enable readinessProbe on IPFS container                                                                                                         | `true`         |
-| `ipfs.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                        | `30`           |
-| `ipfs.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                               | `10`           |
-| `ipfs.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                              | `5`            |
-| `ipfs.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                            | `5`            |
-| `ipfs.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                            | `1`            |
-| `ipfs.extraEnvVars`                       | Extra environment variables for the IPFS container                                                                                              | `[]`           |
-| `ipfs.volumeMounts`                       | Optionally specify extra list of additional volumeMounts for the IPFS container                                                                 | `[]`           |
-| `ipfs.volumes`                            | Optionally specify extra list of additional volumes for the IPFS pod(s)                                                                         | `[]`           |
+| Name                                      | Description                                                                                                                                     | Value               |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `ipfs.enabled`                            | Enable IPFS container within pod                                                                                                                | `true`              |
+| `ipfs.image.registry`                     | IPFS image registry                                                                                                                             | `docker.io`         |
+| `ipfs.image.repository`                   | IPFS image repository                                                                                                                           | `ipfs/kubo`         |
+| `ipfs.image.tag`                          | IPFS image tag (immutable tags are recommended)                                                                                                 | `v0.28.0`           |
+| `ipfs.image.digest`                       | IPFS image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                |
+| `ipfs.image.pullPolicy`                   | IPFS image pull policy                                                                                                                          | `IfNotPresent`      |
+| `ipfs.containerPorts.api`                 | IPFS container API port                                                                                                                         | `5001`              |
+| `ipfs.containerPorts.swarm`               | IPFS container Swarm port                                                                                                                       | `4001`              |
+| `ipfs.resources.limits.cpu`               | The resources limits for the IPFS container for CPU                                                                                             | `500m`              |
+| `ipfs.resources.limits.memory`            | The resources limits for the IPFS container for memory                                                                                          | `512Mi`             |
+| `ipfs.resources.requests.cpu`             | The requested resources for the IPFS container for CPU                                                                                          | `250m`              |
+| `ipfs.resources.requests.memory`          | The requested resources for the IPFS container for memory                                                                                       | `256Mi`             |
+| `ipfs.livenessProbe.enabled`              | Enable livenessProbe on IPFS container                                                                                                          | `true`              |
+| `ipfs.livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe                                                                                                         | `30`                |
+| `ipfs.livenessProbe.periodSeconds`        | Period seconds for livenessProbe                                                                                                                | `10`                |
+| `ipfs.livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe                                                                                                               | `5`                 |
+| `ipfs.livenessProbe.failureThreshold`     | Failure threshold for livenessProbe                                                                                                             | `3`                 |
+| `ipfs.livenessProbe.successThreshold`     | Success threshold for livenessProbe                                                                                                             | `1`                 |
+| `ipfs.readinessProbe.enabled`             | Enable readinessProbe on IPFS container                                                                                                         | `true`              |
+| `ipfs.readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe                                                                                                        | `30`                |
+| `ipfs.readinessProbe.periodSeconds`       | Period seconds for readinessProbe                                                                                                               | `10`                |
+| `ipfs.readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe                                                                                                              | `5`                 |
+| `ipfs.readinessProbe.failureThreshold`    | Failure threshold for readinessProbe                                                                                                            | `5`                 |
+| `ipfs.readinessProbe.successThreshold`    | Success threshold for readinessProbe                                                                                                            | `1`                 |
+| `ipfs.extraEnvVars`                       | Extra environment variables for the IPFS container                                                                                              | `[]`                |
+| `ipfs.volumeMounts`                       | Optionally specify extra list of additional volumeMounts for the IPFS container                                                                 | `[]`                |
+| `ipfs.volumes`                            | Optionally specify extra list of additional volumes for the IPFS pod(s)                                                                         | `[]`                |
+| `ipfs.persistence.enabled`                | Enable IPFS persistence using PVC                                                                                                               | `true`              |
+| `ipfs.persistence.size`                   | IPFS PVC storage request                                                                                                                        | `1Gi`               |
+| `ipfs.persistence.storageClass`           | IPFS PVC Storage Class                                                                                                                          | `""`                |
+| `ipfs.persistence.accessModes`            | IPFS PVC Access Mode                                                                                                                            | `["ReadWriteOnce"]` |
+| `ipfs.persistence.annotations`            | IPFS PVC annotations                                                                                                                            | `{}`                |
 
 ### veritable-cloudagent deployment parameters
 
@@ -139,7 +145,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `image.registry`                                  | veritable-cloudagent image registry                                                                                                                             | `docker.io`                         |
 | `image.repository`                                | veritable-cloudagent image repository                                                                                                                           | `digicatapult/veritable-cloudagent` |
-| `image.tag`                                       | veritable-cloudagent image tag (immutable tags are recommended)                                                                                                 | `v0.10.25`                          |
+| `image.tag`                                       | veritable-cloudagent image tag (immutable tags are recommended)                                                                                                 | `v0.10.27`                          |
 | `image.digest`                                    | veritable-cloudagent image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag image tag (immutable tags are recommended) | `""`                                |
 | `image.pullPolicy`                                | veritable-cloudagent image pull policy                                                                                                                          | `IfNotPresent`                      |
 | `image.pullSecrets`                               | veritable-cloudagent image pull secrets                                                                                                                         | `[]`                                |

--- a/charts/veritable-cloudagent/templates/statefulset.yaml
+++ b/charts/veritable-cloudagent/templates/statefulset.yaml
@@ -326,20 +326,20 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.volumes "context" $) | nindent 4 }}
         {{- end }}
         {{- end }}
-      volumeClaimTemplates:
-        {{- if and .Values.ipfs.enabled .Values.ipfs.persistence.enabled }}
-        - metadata:
-            name: ipfs-data
-            annotations:
-              {{- if .Values.ipfs.persistence.annotations }}
-              {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.persistence.annotations "context" $) | nindent 10 }}
-              {{- end }}
-          spec:
-            accessModes: {{- toYaml .Values.ipfs.persistence.accessModes | nindent 12 }}
-            resources:
-              requests:
-                storage: {{ .Values.ipfs.persistence.size }}
-            {{- if .Values.ipfs.persistence.storageClass }}
-            storageClassName: {{ .Values.ipfs.persistence.storageClass | quote }}
-            {{- end }}
+  volumeClaimTemplates:
+    {{- if and .Values.ipfs.enabled .Values.ipfs.persistence.enabled }}
+    - metadata:
+        name: ipfs-data
+        annotations:
+          {{- if .Values.ipfs.persistence.annotations }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.persistence.annotations "context" $) | nindent 10 }}
+          {{- end }}
+      spec:
+        accessModes: {{- toYaml .Values.ipfs.persistence.accessModes | nindent 8 }}
+        resources:
+          requests:
+            storage: {{ .Values.ipfs.persistence.size }}
+        {{- if .Values.ipfs.persistence.storageClass }}
+        storageClassName: {{ .Values.ipfs.persistence.storageClass | quote }}
         {{- end }}
+    {{- end }}

--- a/charts/veritable-cloudagent/templates/statefulset.yaml
+++ b/charts/veritable-cloudagent/templates/statefulset.yaml
@@ -1,5 +1,5 @@
-apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
-kind: Deployment
+apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
+kind: StatefulSet
 metadata:
   name: {{ template "common.names.fullname" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
@@ -12,11 +12,12 @@ metadata:
   annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
   {{- end }}
 spec:
+  serviceName: {{ template "common.names.fullname" . }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   {{- if .Values.updateStrategy }}
-  strategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
+  updateStrategy: {{- toYaml .Values.updateStrategy | nindent 4 }}
   {{- end }}
   selector:
     matchLabels: {{- include "common.labels.matchLabels" . | nindent 6 }}
@@ -272,6 +273,8 @@ spec:
           ports:
             - name: api
               containerPort: {{ .Values.ipfs.containerPorts.api }}
+            - name: swarm
+              containerPort: {{ .Values.ipfs.containerPorts.swarm }}
           volumeMounts:
             - name: ipfs-data
               mountPath: /data/ipfs
@@ -315,9 +318,28 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
         {{- if eq .Values.ipfs.enabled true }}
+        {{- if and .Values.ipfs.enabled (not .Values.ipfs.persistence.enabled) }}
         - name: ipfs-data
           emptyDir: {}
+        {{- end }}
         {{- if .Values.ipfs.volumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.volumes "context" $) | nindent 4 }}
         {{- end }}
+        {{- end }}
+      volumeClaimTemplates:
+        {{- if and .Values.ipfs.enabled .Values.ipfs.persistence.enabled }}
+        - metadata:
+            name: ipfs-data
+            annotations:
+              {{- if .Values.ipfs.persistence.annotations }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.persistence.annotations "context" $) | nindent 10 }}
+              {{- end }}
+          spec:
+            accessModes: {{- toYaml .Values.ipfs.persistence.accessModes | nindent 8 }}
+            resources:
+              requests:
+                storage: {{ .Values.ipfs.persistence.size }}
+            {{- if .Values.ipfs.persistence.storageClass }}
+            storageClassName: {{ .Values.ipfs.persistence.storageClass | quote }}
+            {{- end }}
         {{- end }}

--- a/charts/veritable-cloudagent/templates/statefulset.yaml
+++ b/charts/veritable-cloudagent/templates/statefulset.yaml
@@ -335,7 +335,7 @@ spec:
               {{- include "common.tplvalues.render" (dict "value" .Values.ipfs.persistence.annotations "context" $) | nindent 10 }}
               {{- end }}
           spec:
-            accessModes: {{- toYaml .Values.ipfs.persistence.accessModes | nindent 8 }}
+            accessModes: {{- toYaml .Values.ipfs.persistence.accessModes | nindent 12 }}
             resources:
               requests:
                 storage: {{ .Values.ipfs.persistence.size }}

--- a/charts/veritable-cloudagent/values.yaml
+++ b/charts/veritable-cloudagent/values.yaml
@@ -221,8 +221,7 @@ ipfs:
     enabled: true
     size: 1Gi
     storageClass: ""  # Set to your desired StorageClass
-    accessModes:
-      - ReadWriteOnce
+    accessModes: ["ReadWriteOnce"]
     annotations: {}
 
 ## @section veritable-cloudagent deployment parameters

--- a/charts/veritable-cloudagent/values.yaml
+++ b/charts/veritable-cloudagent/values.yaml
@@ -138,9 +138,11 @@ ipfs:
     pullPolicy: IfNotPresent
 
   ## @param ipfs.containerPorts.api IPFS container API port
+  ## @param ipfs.containerPorts.swarm IPFS container Swarm port
   ##
   containerPorts:
     api: 5001
+    swarm: 4001
 
   ## IPFS container resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -206,6 +208,22 @@ ipfs:
   ## @param ipfs.volumes Optionally specify extra list of additional volumes for the IPFS pod(s)
   ##
   volumes: []
+  ## IPFS container Persistence parameters
+  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+  ## @param ipfs.persistence.enabled Enable IPFS persistence using PVC
+  ## @param ipfs.persistence.size IPFS PVC storage request
+  ## @param ipfs.persistence.storageClass IPFS PVC Storage Class
+  ## @param ipfs.persistence.accessModes IPFS PVC Access Mode
+  ## @param ipfs.persistence.annotations IPFS PVC annotations
+  ##
+
+  persistence:
+    enabled: true
+    size: 1Gi
+    storageClass: ""  # Set to your desired StorageClass
+    accessModes:
+      - ReadWriteOnce
+    annotations: {}
 
 ## @section veritable-cloudagent deployment parameters
 ## Digital Catapult veritable-cloudagent image
@@ -221,7 +239,7 @@ ipfs:
 image:
   registry: docker.io
   repository: digicatapult/veritable-cloudagent
-  tag: v0.10.25
+  tag: v0.10.27
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

VR-238

## High level description

Converts the deployment to a statefulset

## Detailed description

Converts the deployment to a statefulset
Adds persistence options to the ipfs data PVC
Optionally allows an emptyDir if persistence is disabled
Bumps the container version


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
