### PR TITLE
Do not automerge kubo minor version

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -41,13 +41,6 @@ module.exports = (config = {}) => {
       },
       {
         description:
-          "Group updates per dependency across Chart.yaml and values.yaml",
-        matchManagers: ["helm-values", "regex"],
-        groupName: "{{{depName}}}",
-        labels: ["dependencies", "helm"],
-      },
-      {
-        description:
           "Always bump chart version by a patch when updating values files.",
         matchManagers: ["helm-values", "regex"],
         postUpgradeTasks: {

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -32,6 +32,14 @@ module.exports = (config = {}) => {
     ],
     packageRules: [
       {
+        description: "Do not automerge minor updates for kubo in helm-values",
+        matchManagers: ["helm-values"],
+        matchDepNames: ["docker.io/ipfs/kubo"],
+        matchUpdateTypes: ["minor"],
+        automerge: false,
+        labels: ["dependencies", "helm"],
+      },
+      {
         description:
           "Group updates per dependency across Chart.yaml and values.yaml",
         matchManagers: ["helm-values", "regex"],

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -32,10 +32,10 @@ module.exports = (config = {}) => {
     ],
     packageRules: [
       {
-        description: "Do not automerge minor updates for kubo in helm-values",
+        description: "Do not automerge updates for kubo in helm-values",
         matchManagers: ["helm-values"],
         matchDepNames: ["docker.io/ipfs/kubo"],
-        matchUpdateTypes: ["minor"],
+        matchUpdateTypes: ["minor", "patch"],
         automerge: false,
         labels: ["dependencies", "helm"],
       },


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

ENG-104

## High level description

Do not automerge Kubo updates and do not group updates of same dep

## Detailed description

We do not want kubo updates automerging.
We do not want updates of a similar helm-values dep updating in the same PR, we want them done separately so the bump chart.yaml script runs.


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
