### PR TITLE
Fixing renovate incorrectly grouping deps

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -51,6 +51,13 @@ module.exports = (config = {}) => {
       },
       {
         matchManagers: ["helm-values", "regex"],
+        groupName: "{{{parentDir}}}: {{{depName}}} Updates",
+        labels: ["dependencies", "helm"],
+        separateMinorPatch: true,
+        separateMajorMinor: true,
+      },
+      {
+        matchManagers: ["helm-values", "regex"],
         matchUpdateTypes: ["patch", "minor"],
         automerge: true,
         automergeType: "pr",


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix

## Linked tickets

ENG-104

## High level description

Renovate is incorrectly grouping deps

## Detailed description

We should get individual PRs now we are grouping by chartName dir.


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A
