### PR TITLE
Disable kubo automerge

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -32,14 +32,6 @@ module.exports = (config = {}) => {
     ],
     packageRules: [
       {
-        description: "Do not automerge updates for kubo in helm-values",
-        matchManagers: ["helm-values"],
-        matchDepNames: ["docker.io/ipfs/kubo"],
-        matchUpdateTypes: ["minor", "patch"],
-        automerge: false,
-        labels: ["dependencies", "helm"],
-      },
-      {
         description:
           "Always bump chart version by a patch when updating values files.",
         matchManagers: ["helm-values", "regex"],
@@ -66,6 +58,14 @@ module.exports = (config = {}) => {
       {
         matchManagers: ["helm-values", "regex"],
         matchUpdateTypes: ["major"],
+        automerge: false,
+        labels: ["dependencies", "helm"],
+      },
+      {
+        description: "Do not automerge updates for kubo in helm-values",
+        matchManagers: ["helm-values"],
+        matchDepNames: ["docker.io/ipfs/kubo"],
+        matchUpdateTypes: ["minor", "patch"],
         automerge: false,
         labels: ["dependencies", "helm"],
       },


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

ENG-104

## High level description

Disable Kubo

## Detailed description

Because the kubo automerge off rule was BEFORE the automerge minor/patch the latter took precedence.  This reverses that.


## Describe alternatives you've considered

N/A

## Operational impact

N/A

## Additional context

N/A