### PR TITLE
Use full version of renovatebot/renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           token: ${{ steps.get_token.outputs.token }}
           configurationFile: renovate.config.js
+          renovate-version: full
         env:
           LOG_LEVEL: debug
           RENOVATE_SELF_HOSTED: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix

## Linked tickets

<!-- If this PR is linked to a JIRA ticket or Github Issue, please provide the ticket URL here. -->

## High level description

Newest image of https://github.com/renovatebot/renovate/releases/tag/39.0.0 removed `npx`, which is used in `bump-chart-version.sh`. Using the `full` version of their image should still contain `npx`

