### PR TITLE
Add validator check

### DIFF
--- a/charts/sqnc-node/Chart.yaml
+++ b/charts/sqnc-node/Chart.yaml
@@ -6,6 +6,6 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy SQNC nodes
 type: application
-version: 7.1.3
+version: 7.1.4
 # renovate: image=digicatapult/sqnc-node
-appVersion: '11.3.0'
+appVersion: '12.2.0'

--- a/charts/sqnc-node/README.md
+++ b/charts/sqnc-node/README.md
@@ -104,6 +104,7 @@ helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm
 | `jaegerAgent.collector.port`        | The port which jaeger agent sends data                                                                | `14250`             |
 | `tests.osShell.image.repository`    | Utility init container image name                                                                     | `bitnami/os-shell`  |
 | `tests.osShell.image.tag`           | Utility init container image tag                                                                      | `latest`            |
+| `tests.blockAuthor.enabled`         | A toggle to enable or disable the container that checks the validator is authoring blocks             | `true`              |
 | `tests.blockAuthor.pollSeconds`     | The delay in seconds between polls of the current block synchronisation state                         | `5`                 |
 | `tests.blockAuthor.timeoutSeconds`  | The timeout in seconds to allow the validator to author a finalised block                             | `300`               |
 | `tests.blockHeight.waitSeconds`     | The delay in seconds before testing the block height                                                  | `30`                |

--- a/charts/sqnc-node/README.md
+++ b/charts/sqnc-node/README.md
@@ -105,7 +105,7 @@ helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm
 | `tests.osShell.image.repository`    | Utility init container image name                                                                     | `bitnami/os-shell`  |
 | `tests.osShell.image.tag`           | Utility init container image tag                                                                      | `latest`            |
 | `tests.blockAuthor.pollSeconds`     | The delay in seconds between polls of the current block synchronisation state                         | `5`                 |
-| `tests.blockAuthor.timeoutSeconds`  | The timeout in seconds to allow the validator to author a finalised block                             | `120`               |
+| `tests.blockAuthor.timeoutSeconds`  | The timeout in seconds to allow the validator to author a finalised block                             | `300`               |
 | `tests.blockHeight.waitSeconds`     | The delay in seconds before testing the block height                                                  | `30`                |
 | `tests.nodeConnection.waitSeconds`  | The delay in seconds before testing peer connections against the node                                 | `30`                |
 | `tests.nodeConnection.minPeerCount` | The minimum number of peers needed for production chains; dev and local chains require none           | `2`                 |

--- a/charts/sqnc-node/README.md
+++ b/charts/sqnc-node/README.md
@@ -104,6 +104,8 @@ helm install kusama-node parity/node --set node.chainDataSnapshotUrl=https://ksm
 | `jaegerAgent.collector.port`        | The port which jaeger agent sends data                                                                | `14250`             |
 | `tests.osShell.image.repository`    | Utility init container image name                                                                     | `bitnami/os-shell`  |
 | `tests.osShell.image.tag`           | Utility init container image tag                                                                      | `latest`            |
+| `tests.blockAuthor.pollSeconds`     | The delay in seconds between polls of the current block synchronisation state                         | `5`                 |
+| `tests.blockAuthor.timeoutSeconds`  | The timeout in seconds to allow the validator to author a finalised block                             | `120`               |
 | `tests.blockHeight.waitSeconds`     | The delay in seconds before testing the block height                                                  | `30`                |
 | `tests.nodeConnection.waitSeconds`  | The delay in seconds before testing peer connections against the node                                 | `30`                |
 | `tests.nodeConnection.minPeerCount` | The minimum number of peers needed for production chains; dev and local chains require none           | `2`                 |

--- a/charts/sqnc-node/ci/ct-values.yaml
+++ b/charts/sqnc-node/ci/ct-values.yaml
@@ -13,7 +13,7 @@ node:
 tests:
   blockAuthor:
     pollSeconds: 5
-    timeoutSeconds: 120
+    timeoutSeconds: 300
   blockHeight:
     waitSeconds: 30
   nodeConnection:

--- a/charts/sqnc-node/ci/ct-values.yaml
+++ b/charts/sqnc-node/ci/ct-values.yaml
@@ -12,6 +12,7 @@ node:
     - "--unsafe-force-node-key-generation"
 tests:
   blockAuthor:
+    enabled: true
     pollSeconds: 5
     timeoutSeconds: 300
   blockHeight:

--- a/charts/sqnc-node/ci/ct-values.yaml
+++ b/charts/sqnc-node/ci/ct-values.yaml
@@ -9,7 +9,11 @@ node:
     - "--rpc-cors=all"
     - "--unsafe-rpc-external"
     - "--detailed-log-output"
+    - "--unsafe-force-node-key-generation"
 tests:
+  blockAuthor:
+    pollSeconds: 5
+    timeoutSeconds: 120
   blockHeight:
     waitSeconds: 30
   nodeConnection:

--- a/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
+++ b/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
@@ -19,6 +19,7 @@ metadata:
     "helm.sh/hook": post-install
 spec:
   containers:
+    {{- if ne $blockAuthor.enabled false }}
     {{- if eq $.Values.node.role "validator" }}
     - name: block-author-check
       image: {{ $osShell.repository }}:{{ $osShell.tag }}
@@ -59,6 +60,7 @@ spec:
           value: {{ default 5 $blockAuthor.pollSeconds | quote }}
         - name: BLOCK_AUTHOR_TIMEOUT
           value: {{ default 300 $blockAuthor.timeoutSeconds | quote }}
+    {{- end }}
     {{- end }}
     - name: block-height-check
       image: {{ $osShell.repository }}:{{ $osShell.tag }}

--- a/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
+++ b/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
@@ -58,7 +58,7 @@ spec:
         - name: BLOCK_AUTHOR_POLL
           value: {{ default 5 $blockAuthor.pollSeconds | quote }}
         - name: BLOCK_AUTHOR_TIMEOUT
-          value: {{ default 120 $blockAuthor.timeoutSeconds | quote }}
+          value: {{ default 300 $blockAuthor.timeoutSeconds | quote }}
     {{- end }}
     - name: block-height-check
       image: {{ $osShell.repository }}:{{ $osShell.tag }}

--- a/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
+++ b/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
@@ -47,14 +47,6 @@ spec:
           done
 
           echo "last finalised block authored by the node was (block ID) $LASTAUTHOREDFINALISEDBLOCK"
-
-          PEERS=`curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "system_health"}' "http://{{ $fullname }}-{{ $i }}:9944" | jq '.result.peers'`
-          if [ $PEERS = 0 ]; then
-            echo "no peers found for the validator"
-            exit
-          else
-            echo "validator has $PEERS peers connected"
-          fi
       env:
         - name: BLOCK_AUTHOR_POLL
           value: {{ default 5 $blockAuthor.pollSeconds | quote }}

--- a/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
+++ b/charts/sqnc-node/templates/tests/checkPostDeployment.yaml
@@ -2,6 +2,7 @@
 {{ $serviceLabels :=  include "sqnc-node.serviceLabels" .  }}
 {{ $selectorLabels :=  include "sqnc-node.selectorLabels" .  }}
 
+{{- $blockAuthor := $.Values.tests.blockAuthor | default dict }}
 {{- $blockHeight := $.Values.tests.blockHeight | default dict }}
 {{- $nodeConnection := $.Values.tests.nodeConnection | default dict }}
 
@@ -18,6 +19,47 @@ metadata:
     "helm.sh/hook": post-install
 spec:
   containers:
+    {{- if eq $.Values.node.role "validator" }}
+    - name: block-author-check
+      image: {{ $osShell.repository }}:{{ $osShell.tag }}
+      command: [ "/bin/sh" ]
+      args:
+        - -c
+        - |
+          count=$((0))
+          LASTAUTHOREDFINALISEDBLOCK=0
+          while [ $LASTAUTHOREDFINALISEDBLOCK = 0 ]; do
+            sleep "$BLOCK_AUTHOR_POLL"s
+            SYNC_STATE_EXTENDED=`curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "sqnc_syncStateExtended"}' "http://{{ $fullname }}-{{ $i }}:9944" | jq '.result'`
+
+            eval "$(echo $SYNC_STATE_EXTENDED | jq -r 'to_entries | map("\(.key | ascii_upcase)=\(.value | @sh)") | .[]')"
+
+            echo "waiting for a finalised block to have been authored by the node"
+
+            echo "block height after ${BLOCK_AUTHOR_POLL}s: $CURRENTBLOCK"
+
+            count=$((count+BLOCK_AUTHOR_POLL))
+            if [ $count -ge $BLOCK_AUTHOR_TIMEOUT ]; then
+              echo "block finalisation timed out after $count seconds; no change in author detected"
+              break
+            fi
+          done
+
+          echo "last finalised block authored by the node was (block ID) $LASTAUTHOREDFINALISEDBLOCK"
+
+          PEERS=`curl -sS -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "system_health"}' "http://{{ $fullname }}-{{ $i }}:9944" | jq '.result.peers'`
+          if [ $PEERS = 0 ]; then
+            echo "no peers found for the validator"
+            exit
+          else
+            echo "validator has $PEERS peers connected"
+          fi
+      env:
+        - name: BLOCK_AUTHOR_POLL
+          value: {{ default 5 $blockAuthor.pollSeconds | quote }}
+        - name: BLOCK_AUTHOR_TIMEOUT
+          value: {{ default 120 $blockAuthor.timeoutSeconds | quote }}
+    {{- end }}
     - name: block-height-check
       image: {{ $osShell.repository }}:{{ $osShell.tag }}
       command: [ "/bin/sh" ]

--- a/charts/sqnc-node/values.yaml
+++ b/charts/sqnc-node/values.yaml
@@ -165,6 +165,7 @@ tests:
       repository: bitnami/os-shell
       tag: latest
   # blockAuthor:
+  #   enabled: true
   #   pollSeconds: 5
   #   timeoutSeconds: 120
   # blockHeight:

--- a/charts/sqnc-node/values.yaml
+++ b/charts/sqnc-node/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: digicatapult/sqnc-node
-  tag: v11.3.0
+  tag: v12.2.0
   pullPolicy: Always
 
 initContainer:
@@ -164,6 +164,9 @@ tests:
     image:
       repository: bitnami/os-shell
       tag: latest
+  # blockAuthor:
+  #   pollSeconds: 5
+  #   timeoutSeconds: 120
   # blockHeight:
   #   waitSeconds: 30
   # nodeConnection:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

SQNC-55
SQNC-105
SQNC-139

## High level description

With sqnc-node v12.2.0, there is an RPC method for getting the ID of a block known to have been authored by the local node. This makes it practical to write a CI post-deployment script to check whether the node under test is authoring blocks. Between v11.x and v12.2.0, there was a breaking change upstream (Substrate) around the assumption that validators might disconnect unexpectedly from the network and yet continue to author blocks, potentially rendering them untrustworthy. This change requires the inclusion of the flag `--unsafe-force-node-key-generation` in `ci/ct-values.yaml`.