### PR TITLE
Add repo migration in config init for sqnc-ipfs

### DIFF
--- a/charts/sqnc-ipfs/Chart.yaml
+++ b/charts/sqnc-ipfs/Chart.yaml
@@ -6,7 +6,7 @@ name: sqnc-ipfs
 description: sqnc-ipfs is a component of the SQNC project that provides a distributed IPFS based storage solution for the SQNC platform.
 # renovate: image=digicatapult/sqnc-ipfs
 appVersion: v3.0.17
-version: 4.0.34
+version: 4.0.35
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
@@ -25,7 +25,7 @@ icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/ass
 keywords:
   - SQNC
 maintainers:
-  - name: digicatapult  # Digital Catapult
+  - name: digicatapult # Digital Catapult
     url: https://github.com/digicatapult/helm-charts
     email: opensource@digicatapult.org.uk
 sources:

--- a/charts/sqnc-ipfs/templates/statefulset.yaml
+++ b/charts/sqnc-ipfs/templates/statefulset.yaml
@@ -117,6 +117,7 @@ spec:
             - |
               [ ! -f "{{ .Values.persistence.mountPath }}/config" ] && {{ .Values.ipfs.binary }} init --profile server;
               export POD_INDEX="${HOSTNAME##*-}";
+              {{ .Values.ipfs.binary }} repo migrate;
               {{ .Values.ipfs.binary }} config Addresses.API /ip4/0.0.0.0/tcp/{{ .Values.apiService.ports.api | default 5001 }};
               {{ .Values.ipfs.binary }} config --json Addresses.Swarm "[\"/ip4/0.0.0.0/tcp/{{ .Values.swarmService.ports.swarm }}\"]";
               {{ .Values.ipfs.binary }} config --json Addresses.Announce "[\"/dns4/{{ include "common.names.fullname" . }}-$(echo "$POD_INDEX")-swarm.{{ .Release.Namespace }}.svc.cluster.local/tcp/{{ .Values.swarmService.ports.swarm }}/\"]";


### PR DESCRIPTION
# Pull Request

## Checklist
- [ ] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [ ] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-135

## High level description

Adds repo migration to config init

## Detailed description

`sqnc-ipfs` executes an init container that manipulates the config. This currently fails because the ipfs repo requires migration. This change adds this migration

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

None
