### PR TITLE
Downgrade PostgreSQL sub-chart for SQNC

### DIFF
--- a/charts/sqnc-attachment-api/Chart.lock
+++ b/charts/sqnc-attachment-api/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.5.6
+  version: 15.5.38
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.27.0
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
-  version: 24.4.13
+  version: 24.5.1
 - name: sqnc-node
   repository: https://digicatapult.github.io/helm-charts/
-  version: 7.1.11
+  version: 7.1.16
 - name: sqnc-identity-service
   repository: https://digicatapult.github.io/helm-charts/
-  version: 5.0.0
+  version: 5.1.1
 - name: sqnc-ipfs
   repository: https://digicatapult.github.io/helm-charts/
-  version: 4.0.41
-digest: sha256:190babbf54cdaff92a9191ea05d6aa53e9dc84e016e42ab754ac5849baa61037
-generated: "2025-03-27T15:41:37.722904Z"
+  version: 4.0.43
+digest: sha256:5e8aa8d885a6b6b56ef79754e4573e5997c8fbfdd32053437fdefa8962af326e
+generated: "2025-04-09T10:50:01.811211+01:00"

--- a/charts/sqnc-attachment-api/Chart.yaml
+++ b/charts/sqnc-attachment-api/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x
+    version: 15.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:

--- a/charts/sqnc-identity-service/Chart.lock
+++ b/charts/sqnc-identity-service/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.0.0
+  version: 15.5.38
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.24.0
+  version: 2.27.0
 - name: sqnc-node
   repository: https://digicatapult.github.io/helm-charts/
-  version: 7.0.1
-digest: sha256:09025f0080603b4a0c32c91112c6f171330366a7ecc1149eed70084f3cabc4a5
-generated: "2024-10-03T10:17:02.48485672Z"
+  version: 7.1.16
+digest: sha256:da6560729d5dade5f8e1f70d2343353c5fc86f58258982877d3b26f8acbfb8a9
+generated: "2025-04-09T10:50:38.143696+01:00"

--- a/charts/sqnc-identity-service/Chart.yaml
+++ b/charts/sqnc-identity-service/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x
+    version: 15.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:

--- a/charts/sqnc-matchmaker-api/Chart.lock
+++ b/charts/sqnc-matchmaker-api/Chart.lock
@@ -1,21 +1,21 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.0
+  version: 15.5.38
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.27.0
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
-  version: 24.4.13
+  version: 24.5.1
 - name: sqnc-node
   repository: https://digicatapult.github.io/helm-charts/
-  version: 7.1.11
+  version: 7.1.16
 - name: sqnc-identity-service
   repository: https://digicatapult.github.io/helm-charts/
-  version: 5.1.0
+  version: 5.1.1
 - name: sqnc-attachment-api
   repository: https://digicatapult.github.io/helm-charts/
-  version: 2.0.0
-digest: sha256:016399c2187fc4f0f6fb5614a3718439e549d6fae14f9e7c09482bb9575fca4b
-generated: "2025-03-28T11:48:14.862751Z"
+  version: 2.0.8
+digest: sha256:6c50e7c0ae07f533ef3bcc78813e50a084b230ee4240f3d5354f9434225eabde
+generated: "2025-04-09T10:40:40.80882+01:00"

--- a/charts/sqnc-matchmaker-api/Chart.yaml
+++ b/charts/sqnc-matchmaker-api/Chart.yaml
@@ -8,7 +8,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x
+    version: 15.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## Linked tickets

SQNC-157

## High level description

There isn't a standard method to upgrade Bitnami's PostgreSQL charts once deployed; the differences between major versions of PostgreSQL are breaking. Our agreed workaround is to downgrade the PostgreSQL version used as a sub-chart, i.e. move from v16 to v15 of the Bitnami chart, to remove it as an obstacle to the upgrading of other SQNC components. Note that version 16 of Bitnami's PostgreSQL chart corresponds to PostgreSQL v17.

## Describe alternatives you've considered

Several methods to address the PostgreSQL problem were considered:
- Use an extra deploy job to execute `pg_dump` and `psql` with different versions and then move files around
- Use manual deployments of the new PostgreSQL version and then update the chart to point at it
- Use multiple sub-charts for each major version of PostgreSQL
- Use an external instance of PostgreSQL, i.e. that isn't a sub-chart

## Operational impact

Both staging and production are currently using PostgreSQL v16 anyway, so the main impact is to remove an immediate blocker for other upgrades.