### PR TITLE
Add dependency name to ignore list

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -16,7 +16,10 @@ module.exports = (config = {}) => {
     onboarding: false,
     requireConfig: false,
     allowedPostUpgradeCommands: ["scripts/bump-chart-version.sh"],
-    ignoreDeps: ["docker.io/bitnami/postgresql"],
+    ignoreDeps: [
+      "postgresql",
+      "docker.io/bitnami/postgresql"
+    ],
     prHourlyLimit: 20,
     prConcurrentLimit: 20,
     recreateWhen: "always",


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## High level description

Renovate doesn't appear to be matching "docker.io/bitnami/postgresql", as that upgrade is still being attempted. It's assumed that the correct dependency name is just "postgresql".