### PR TITLE
Downgrade PostgreSQL version in matchmaker API

### DIFF
--- a/charts/sqnc-matchmaker-api/Chart.lock
+++ b/charts/sqnc-matchmaker-api/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.0
+  version: 15.5.38
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.27.0
@@ -13,9 +13,9 @@ dependencies:
   version: 7.1.11
 - name: sqnc-identity-service
   repository: https://digicatapult.github.io/helm-charts/
-  version: 5.1.0
+  version: 5.1.2
 - name: sqnc-attachment-api
   repository: https://digicatapult.github.io/helm-charts/
   version: 2.0.0
-digest: sha256:016399c2187fc4f0f6fb5614a3718439e549d6fae14f9e7c09482bb9575fca4b
-generated: "2025-03-28T11:48:14.862751Z"
+digest: sha256:1993c62177a3a2ac8082c020f22f49cfd1584eef1ff22843a97771c1a68adc97
+generated: "2025-04-10T11:24:04.437346+01:00"

--- a/charts/sqnc-matchmaker-api/Chart.yaml
+++ b/charts/sqnc-matchmaker-api/Chart.yaml
@@ -8,36 +8,36 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x
+    version: 15.x
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.x.x
+    version: 2.27.0
   - condition: keycloak.enabled
     name: keycloak
     repository: https://charts.bitnami.com/bitnami
-    version: 24.x
+    version: 24.4.13
   - name: sqnc-node
     alias: node
     repository: https://digicatapult.github.io/helm-charts/
     tags:
       - sqnc-node
-    version: 7.x.x
+    version: 7.1.11
     condition: node.enabled
   - name: sqnc-identity-service
     alias: identity
     repository: https://digicatapult.github.io/helm-charts/
     tags:
       - sqnc-identity-service
-    version: 5.x
+    version: 5.1.2
     condition: identity.enabled
   - name: sqnc-attachment-api
     alias: attachment
     repository: https://digicatapult.github.io/helm-charts/
     tags:
       - sqnc-attachment-api
-    version: 2.x.x
+    version: 2.0.0
     condition: attachment.enabled
 description: The sqnc-matchmaker-api is a component of the Sequence (SQNC) ledger-based system.
 home: https://github.com/digicatapult/sqnc-documentation
@@ -51,4 +51,4 @@ maintainers:
 name: sqnc-matchmaker-api
 sources:
   - https://github.com/digicatapult/sqnc-matchmaker-api
-version: 4.0.1
+version: 4.0.2


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Chore

## Linked tickets

SQNC-157

## High level description

This PR downgrades PostgreSQL for the matchmaker API. It's necessary to ensure that there are no breaking changes to the PostgreSQL sub-chart whenever production services are upgraded in the future. There isn't a standard method to upgrade Bitnami's PostgreSQL charts once deployed; the differences between major versions of PostgreSQL are breaking. Our agreed workaround is to downgrade the PostgreSQL version used as a sub-chart, i.e. move from v16 to v15 of the Bitnami chart, to remove it as an obstacle to the upgrading of other SQNC components. Note that version 16 of Bitnami's PostgreSQL chart corresponds to PostgreSQL v17.

## Describe alternatives you've considered

Several methods to address the PostgreSQL problem were considered:

- Use an extra deploy job to execute pg_dump and psql with different versions and then move files around
- Use manual deployments of the new PostgreSQL version and then update the chart to point at it
- Use multiple sub-charts for each major version of PostgreSQL
- Use an external instance of PostgreSQL, i.e. that isn't a sub-chart

## Operational impact

Both staging and production are currently using PostgreSQL v16 anyway, so the main impact is to remove an immediate blocker for other upgrades.