### PR TITLE
Disable API merger PVCs

### DIFF
--- a/charts/openapi-merger/Chart.yaml
+++ b/charts/openapi-merger/Chart.yaml
@@ -29,4 +29,4 @@ maintainers:
 name: openapi-merger
 sources:
   - https://github.com/digicatapult/openapi-merger
-version: 2.1.81
+version: 2.1.82

--- a/charts/openapi-merger/README.md
+++ b/charts/openapi-merger/README.md
@@ -175,7 +175,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Name                        | Description                                                                                             | Value               |
 | --------------------------- | ------------------------------------------------------------------------------------------------------- | ------------------- |
-| `persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `true`              |
+| `persistence.enabled`       | Enable persistence using Persistent Volume Claims                                                       | `false`             |
 | `persistence.mountPath`     | Path to mount the volume at.                                                                            | `/data`             |
 | `persistence.subPath`       | The subdirectory of the volume to mount to, useful in dev environments and one PV for multiple services | `""`                |
 | `persistence.storageClass`  | Storage class of backing PVC                                                                            | `""`                |

--- a/charts/openapi-merger/values.yaml
+++ b/charts/openapi-merger/values.yaml
@@ -441,7 +441,7 @@ initContainers: []
 persistence:
   ## @param persistence.enabled Enable persistence using Persistent Volume Claims
   ##
-  enabled: true
+  enabled: false
   ## @param persistence.mountPath Path to mount the volume at.
   ##
   mountPath: /data


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix
- [x] Chore

## High level description

On production, the open API merger PVCs were no longer being created for unknown reasons. These PVCs are unnecessary, so setting the default to `false` in the chart is the safer option to prevent a recurrence of the issue.

## Operational impact

With the PVCs enabled, there is the slight risk that a similar issue recurs and effectively renders the services inaccessible (503). So, the impact of updating the pods to not use PVCs is negligible, practically zero, and it ensures that the services aren't affected by the issue.

## Additional context

Upscaling the node pool didn't resolve the issue with the PVCs; they still weren't being created.