### PR TITLE
ignore upgrades to sqnc-node as helm dependency

### DIFF
--- a/renovate.config.js
+++ b/renovate.config.js
@@ -16,10 +16,7 @@ module.exports = (config = {}) => {
     onboarding: false,
     requireConfig: false,
     allowedPostUpgradeCommands: ["scripts/bump-chart-version.sh"],
-    ignoreDeps: [
-      "postgresql",
-      "docker.io/bitnami/postgresql"
-    ],
+    ignoreDeps: ["postgresql", "docker.io/bitnami/postgresql"],
     prHourlyLimit: 20,
     prConcurrentLimit: 20,
     recreateWhen: "always",
@@ -29,12 +26,17 @@ module.exports = (config = {}) => {
         datasourceTemplate: "docker",
         fileMatch: ["(^|/)Chart\\.yaml$"],
         matchStrings: [
-          '#\\s*renovate: image=(?<imageName>.*?)\\s+appVersion:\\s*[\"]?(?<currentValue>[\\w+\\.\\-]*)',
+          '#\\s*renovate: image=(?<imageName>.*?)\\s+appVersion:\\s*["]?(?<currentValue>[\\w+\\.\\-]*)',
         ],
         depNameTemplate: "docker.io/{{{imageName}}}",
       },
     ],
     packageRules: [
+      {
+        matchManagers: ["helmv3"],
+        matchDepNames: ["sqnc-node"],
+        allowedVersions: "<13",
+      },
       {
         matchManagers: ["helm-values", "regex", "helmv3"],
         groupName: null,

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -26,7 +26,7 @@ module.exports = (config = {}) => {
         datasourceTemplate: "docker",
         fileMatch: ["(^|/)Chart\\.yaml$"],
         matchStrings: [
-          '#\\s*renovate: image=(?<imageName>.*?)\\s+appVersion:\\s*["]?(?<currentValue>[\\w+\\.\\-]*)',
+          '#\\s*renovate: image=(?<imageName>.*?)\\s+appVersion:\\s*[\"]?(?<currentValue>[\\w+\\.\\-]*)',
         ],
         depNameTemplate: "docker.io/{{{imageName}}}",
       },


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [ ] Bug Fix
- [x] Chore
- [ ] Feature
- [ ] Documentation Update
- [ ] Code style update (formatting, local variables)
- [ ] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

https://digicatapult.atlassian.net/browse/SQNC-166

## High level description

Add temporary ignore to sqnc-node as a helm dependency as this is creating a lot of noise

## Detailed description

The upgrade to sqnc-node v13 creates a lot of noise as we currently don't have a compatible version of the other services. Hopefully this will prevent upgrading sqnc-node as a helm dep in those other charts whilst that is finished

## Describe alternatives you've considered

None

## Operational impact

None

## Additional context

N/A
