### PR TITLE
Attachment-API storage backends.

### DIFF
--- a/charts/sqnc-attachment-api/Chart.lock
+++ b/charts/sqnc-attachment-api/Chart.lock
@@ -1,21 +1,27 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.5.6
+  version: 16.7.8
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.27.0
+  version: 2.31.1
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
-  version: 24.4.13
+  version: 24.7.3
 - name: sqnc-node
   repository: https://digicatapult.github.io/helm-charts/
-  version: 7.1.11
+  version: 7.1.19
 - name: sqnc-identity-service
   repository: https://digicatapult.github.io/helm-charts/
-  version: 5.0.0
+  version: 5.1.43
 - name: sqnc-ipfs
   repository: https://digicatapult.github.io/helm-charts/
-  version: 4.0.41
-digest: sha256:190babbf54cdaff92a9191ea05d6aa53e9dc84e016e42ab754ac5849baa61037
-generated: "2025-03-27T15:41:37.722904Z"
+  version: 4.0.51
+- name: minio
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.0.10
+- name: azurite
+  repository: https://viters.github.io/azurite-helm-chart/
+  version: 2.0.0
+digest: sha256:da39c6af02821ac4b6468571fb1eab1dd0a9c179be6a4481a9eb154ba6005c17
+generated: "2025-06-03T13:18:00.760515+01:00"

--- a/charts/sqnc-attachment-api/Chart.yaml
+++ b/charts/sqnc-attachment-api/Chart.yaml
@@ -39,6 +39,14 @@ dependencies:
       - sqnc-ipfs
     version: 4.x.x
     condition: ipfs.enabled
+  - name: minio
+    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 16.x
+    condition: minio.enabled
+  - name: azurite
+    repository: https://viters.github.io/azurite-helm-chart/
+    version: 2.x
+    condition: azurite.enabled
 description: The sqnc-attachment-api is a component of the Sequence (SQNC) ledger-based system.
 home: https://github.com/digicatapult/sqnc-documentation
 icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/assets/icon.png
@@ -51,4 +59,4 @@ maintainers:
 name: sqnc-attachment-api
 sources:
   - https://github.com/digicatapult/sqnc-attachment-api
-version: 3.0.22
+version: 3.1.0

--- a/charts/sqnc-attachment-api/README.md
+++ b/charts/sqnc-attachment-api/README.md
@@ -267,12 +267,11 @@ The command removes all the Kubernetes components associated with the chart and 
 | `node.nameOverride`     | String to partially override sqnc-node.fullname template (will maintain the release name) | `""`    |
 | `node.fullnameOverride` | String to fully override sqnc-node.fullname template                                      | `""`    |
 
-### SQNC-Ipfs parameters
+### Keycloak Parameters
 
-| Name                    | Description                 | Value |
-| ----------------------- | --------------------------- | ----- |
-| `externalSqncIpfs.host` | External SQNC-Ipfs hostname | `""`  |
-| `externalSqncIpfs.port` | External SQNC-Ipfs port     | `""`  |
+| Name               | Description              | Value   |
+| ------------------ | ------------------------ | ------- |
+| `keycloak.enabled` | Enable Keycloak subchart | `false` |
 
 ### SQNC-Identity-Service parameters
 
@@ -281,23 +280,38 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalSqncIdentity.host` | External SQNC-Identity-Service hostname | `""`  |
 | `externalSqncIdentity.port` | External SQNC-Identity-Service port     | `""`  |
 
-### Keycloak Parameters
-
-| Name               | Description              | Value   |
-| ------------------ | ------------------------ | ------- |
-| `keycloak.enabled` | Enable Keycloak subchart | `false` |
-
 ### SQNC Identity Service Parameters
 
 | Name               | Description                           | Value   |
 | ------------------ | ------------------------------------- | ------- |
 | `identity.enabled` | Enable sqnc-identity-service subchart | `false` |
 
-### SQNC Ipfs Parameters
+### Backend Storage Parameters
 
-| Name           | Description               | Value   |
-| -------------- | ------------------------- | ------- |
-| `ipfs.enabled` | Enable sqnc-ipfs subchart | `false` |
+| Name                                          | Description                                                                      | Value             |
+| --------------------------------------------- | -------------------------------------------------------------------------------- | ----------------- |
+| `storageBackend.mode`                         | Storage mode to use, choice of IPFS, AZURE or S3                                 | `IPFS`            |
+| `storageBackend.accessKeyId`                  | The access key ID to use for the s3 storageBackend                               | `""`              |
+| `storageBackend.secretAccessKey`              | The secret access key to use for the s3 storageBackend                           | `""`              |
+| `storageBackend.s3Region`                     | The AWS region to use with Amazon S3                                             | `""`              |
+| `storageBackend.bucketName`                   | The bucket or storageContainer name to use                                       | `""`              |
+| `storageBackend.protocol`                     | The Protocol to use for accessing the storage backend, options are http or https | `https`           |
+| `storageBackend.existingS3Secret`             | The existing Secret to use for the s3 Credentials                                | `""`              |
+| `storageBackend.existingS3SecretAccessKeyKey` | The key to use for the S3 SecretaccessKey                                        | `secretAccessKey` |
+| `storageBackend.existingS3AccessKeyIdKey`     | The key to use for the S3 AccessKeyId                                            | `accessKeyId`     |
+| `storageBackend.accountName`                  | The Account Name to use with Azure                                               | `""`              |
+| `storageBackend.accountKey`                   | The Account Key to use with Azure                                                | `""`              |
+| `storageBackend.blobDomain`                   | The BlobDomain to use with Azure                                                 | `""`              |
+| `storageBackend.existingAzureSecret`          | The existing secret to use for the Azure Credentials                             | `""`              |
+| `storageBackend.existingAzureAccountNameKey`  | The key to use for the Azure AccountName                                         | `accountName`     |
+| `storageBackend.existingAzureAccountKeyKey`   | The key to use for the Azure AccountKey                                          | `accountKey`      |
+| `externalStorageBackend.host`                 |                                                                                  | `""`              |
+| `externalStorageBackend.port`                 |                                                                                  | `""`              |
+| `externalSqncIpfs.host`                       | External SQNC-Ipfs hostname                                                      | `""`              |
+| `externalSqncIpfs.port`                       | External SQNC-Ipfs port                                                          | `""`              |
+| `ipfs.enabled`                                | Enable sqnc-ipfs subchart                                                        | `false`           |
+| `minio.enabled`                               | Enable minio subchart                                                            | `false`           |
+| `azurite.enabled`                             | Enable the azurite subchart                                                      | `false`           |
 
 ### Helm test parameters
 

--- a/charts/sqnc-attachment-api/ci/azurite-value.yaml
+++ b/charts/sqnc-attachment-api/ci/azurite-value.yaml
@@ -1,0 +1,5595 @@
+node:
+  enabled: true
+  fullnameOverride: attachment-node
+  node:
+    chain: dev
+    flags:
+      - "--rpc-external"
+      - "--alice"
+      - "--rpc-methods=Unsafe"
+      - "--rpc-cors=all"
+      - "--unsafe-rpc-external"
+      - "--unsafe-force-node-key-generation"
+
+logLevel: debug
+auth:
+  clientId: sequence
+  publicIdpOrigin: http://localhost:8080
+  internalIdpOrigin: http://attachment-keycloak:80
+  idpPathPrefix: /auth
+  oauth2Realm: sequence
+  internalRealm: internal
+  internalClientId: sequence
+  internalClientSecret: secret
+tests:
+  auth:
+    clientId: sequence
+    clientSecret: secret
+identity:
+  enabled: true
+  node:
+    enabled: false
+  externalSqncNode:
+    host: attachment-node
+    port: 9944
+  auth:
+    clientId: sequence
+    publicIdpOrigin: http://localhost:8080
+    internalIdpOrigin: http://attachment-keycloak:80
+    idpPathPrefix: /auth
+    oauth2Realm: sequence
+    internalRealm: internal
+  postgresql:
+    nameOverride: postgresql-identity
+ipfs:
+  enabled: false
+azurite:
+  enabled: true
+  config:
+    blobs:
+      initJob:
+        enabled: true
+        containers:
+          public: 
+storageBackend:
+  mode: AZURE
+  protocol: http
+keycloak:
+  enabled: true
+  fullnameOverride: attachment-keycloak
+  auth:
+    clientId: sequence
+  httpRelativePath: /auth/
+  extraEnvVars:
+    - name: KC_HOSTNAME_PATH
+      value: /auth/
+    - name: KC_HOSTNAME_PORT
+      value: "8080"
+    - name: KC_HOSTNAME_DEBUG
+      value: "true"
+  extraStartupArgs: "--import-realm"
+  extraVolumes:
+    - name: realm-volume
+      configMap:
+        name: keycloak-realms
+  extraVolumeMounts:
+    - mountPath: /opt/bitnami/keycloak/data/import
+      name: realm-volume
+  resourcesPreset: medium
+  postgresql:
+    enabled: true
+    nameOverride: keycloak-postgres
+  extraDeploy:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: keycloak-realms
+      data:
+        alice.json: |
+          {
+            "realm": "alice",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/alice/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/alice/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/alice/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/alice/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }
+        internal.json: |
+          {
+            "realm": "internal",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/internal/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/internal/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/internal/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/internal/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }
+        external.json: |
+          {
+            "realm": "external",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/external/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/external/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/external/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/external/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }

--- a/charts/sqnc-attachment-api/ci/ipfs-values.yaml
+++ b/charts/sqnc-attachment-api/ci/ipfs-values.yaml
@@ -1,0 +1,5594 @@
+node:
+  enabled: true
+  fullnameOverride: attachment-node
+  node:
+    chain: dev
+    flags:
+      - "--rpc-external"
+      - "--alice"
+      - "--rpc-methods=Unsafe"
+      - "--rpc-cors=all"
+      - "--unsafe-rpc-external"
+      - "--unsafe-force-node-key-generation"
+
+logLevel: debug
+auth:
+  clientId: sequence
+  publicIdpOrigin: http://localhost:8080
+  internalIdpOrigin: http://attachment-keycloak:80
+  idpPathPrefix: /auth
+  oauth2Realm: sequence
+  internalRealm: internal
+  internalClientId: sequence
+  internalClientSecret: secret
+tests:
+  auth:
+    clientId: sequence
+    clientSecret: secret
+identity:
+  enabled: true
+  node:
+    enabled: false
+  externalSqncNode:
+    host: attachment-node
+    port: 9944
+  auth:
+    clientId: sequence
+    publicIdpOrigin: http://localhost:8080
+    internalIdpOrigin: http://attachment-keycloak:80
+    idpPathPrefix: /auth
+    oauth2Realm: sequence
+    internalRealm: internal
+  postgresql:
+    nameOverride: postgresql-identity
+storageBackend:
+  mode: IPFS
+ipfs:
+  enabled: true
+  sqncNode:
+    enabled: false
+  externalSqncNode:
+    host: attachment-node
+    port: 9944
+  service:
+    ports:
+      http: 5001
+keycloak:
+  enabled: true
+  fullnameOverride: attachment-keycloak
+  auth:
+    clientId: sequence
+  httpRelativePath: /auth/
+  extraEnvVars:
+    - name: KC_HOSTNAME_PATH
+      value: /auth/
+    - name: KC_HOSTNAME_PORT
+      value: "8080"
+    - name: KC_HOSTNAME_DEBUG
+      value: "true"
+  extraStartupArgs: "--import-realm"
+  extraVolumes:
+    - name: realm-volume
+      configMap:
+        name: keycloak-realms
+  extraVolumeMounts:
+    - mountPath: /opt/bitnami/keycloak/data/import
+      name: realm-volume
+  resourcesPreset: medium
+  postgresql:
+    enabled: true
+    nameOverride: keycloak-postgres
+  extraDeploy:
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: keycloak-realms
+      data:
+        alice.json: |
+          {
+            "realm": "alice",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/alice/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/alice/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/alice/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/alice/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }
+        internal.json: |
+          {
+            "realm": "internal",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/internal/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/internal/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/internal/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/internal/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }
+        external.json: |
+          {
+            "realm": "external",
+            "notBefore": 0,
+            "defaultSignatureAlgorithm": "RS256",
+            "revokeRefreshToken": false,
+            "refreshTokenMaxReuse": 0,
+            "accessTokenLifespan": 300,
+            "accessTokenLifespanForImplicitFlow": 900,
+            "ssoSessionIdleTimeout": 1800,
+            "ssoSessionMaxLifespan": 36000,
+            "ssoSessionIdleTimeoutRememberMe": 0,
+            "ssoSessionMaxLifespanRememberMe": 0,
+            "offlineSessionIdleTimeout": 2592000,
+            "offlineSessionMaxLifespanEnabled": false,
+            "offlineSessionMaxLifespan": 5184000,
+            "clientSessionIdleTimeout": 0,
+            "clientSessionMaxLifespan": 0,
+            "clientOfflineSessionIdleTimeout": 0,
+            "clientOfflineSessionMaxLifespan": 0,
+            "accessCodeLifespan": 60,
+            "accessCodeLifespanUserAction": 300,
+            "accessCodeLifespanLogin": 1800,
+            "actionTokenGeneratedByAdminLifespan": 43200,
+            "actionTokenGeneratedByUserLifespan": 300,
+            "oauth2DeviceCodeLifespan": 600,
+            "oauth2DevicePollingInterval": 5,
+            "enabled": true,
+            "sslRequired": "external",
+            "registrationAllowed": true,
+            "registrationEmailAsUsername": false,
+            "rememberMe": false,
+            "verifyEmail": false,
+            "loginWithEmailAllowed": true,
+            "duplicateEmailsAllowed": false,
+            "resetPasswordAllowed": false,
+            "editUsernameAllowed": false,
+            "bruteForceProtected": false,
+            "permanentLockout": false,
+            "maxTemporaryLockouts": 0,
+            "maxFailureWaitSeconds": 900,
+            "minimumQuickLoginWaitSeconds": 60,
+            "waitIncrementSeconds": 60,
+            "quickLoginCheckMilliSeconds": 1000,
+            "maxDeltaTimeSeconds": 43200,
+            "failureFactor": 30,
+            "defaultRole": {
+              "name": "default-roles-alice",
+              "description": "${role_default-roles}",
+              "composite": true,
+              "clientRole": false,
+              "containerId": "7d98085d-95c8-40b0-ab8f-d0d3fc182833"
+            },
+            "requiredCredentials": [
+              "password"
+            ],
+            "otpPolicyType": "totp",
+            "otpPolicyAlgorithm": "HmacSHA1",
+            "otpPolicyInitialCounter": 0,
+            "otpPolicyDigits": 6,
+            "otpPolicyLookAheadWindow": 1,
+            "otpPolicyPeriod": 30,
+            "otpPolicyCodeReusable": false,
+            "otpSupportedApplications": [
+              "totpAppFreeOTPName",
+              "totpAppGoogleName",
+              "totpAppMicrosoftAuthenticatorName"
+            ],
+            "localizationTexts": {},
+            "webAuthnPolicyRpEntityName": "keycloak",
+            "webAuthnPolicySignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyRpId": "",
+            "webAuthnPolicyAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyRequireResidentKey": "not specified",
+            "webAuthnPolicyUserVerificationRequirement": "not specified",
+            "webAuthnPolicyCreateTimeout": 0,
+            "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyAcceptableAaguids": [],
+            "webAuthnPolicyExtraOrigins": [],
+            "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+            "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+              "ES256"
+            ],
+            "webAuthnPolicyPasswordlessRpId": "",
+            "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+            "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+            "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+            "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+            "webAuthnPolicyPasswordlessCreateTimeout": 0,
+            "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+            "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+            "webAuthnPolicyPasswordlessExtraOrigins": [],
+            "users": [
+              {
+                "username": "service-account-sequence",
+                "emailVerified": false,
+                "createdTimestamp": 1716216657619,
+                "enabled": true,
+                "totp": false,
+                "serviceAccountClientId": "sequence",
+                "disableableCredentialTypes": [],
+                "requiredActions": [],
+                "notBefore": 0
+              }
+            ],
+            "scopeMappings": [
+              {
+                "clientScope": "offline_access",
+                "roles": [
+                  "offline_access"
+                ]
+              }
+            ],
+            "clientScopeMappings": {
+              "account": [
+                {
+                  "client": "account-console",
+                  "roles": [
+                    "manage-account",
+                    "view-groups"
+                  ]
+                }
+              ]
+            },
+            "clients": [
+              {
+                "clientId": "account",
+                "name": "${client_account}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/external/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/external/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "account-console",
+                "name": "${client_account-console}",
+                "rootUrl": "${authBaseUrl}",
+                "baseUrl": "/realms/external/account/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/realms/external/account/*"
+                ],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {}
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "admin-cli",
+                "name": "${client_admin-cli}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": false,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": true,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "broker",
+                "name": "${client_broker}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "realm-management",
+                "name": "${client_realm-management}",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [],
+                "webOrigins": [],
+                "notBefore": 0,
+                "bearerOnly": true,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": false,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {},
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "security-admin-console",
+                "name": "${client_security-admin-console}",
+                "rootUrl": "${authAdminUrl}",
+                "baseUrl": "/admin/alice/console/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "redirectUris": [
+                  "/admin/alice/console/*"
+                ],
+                "webOrigins": [
+                  "+"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": false,
+                "publicClient": true,
+                "frontchannelLogout": false,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "post.logout.redirect.uris": "+",
+                  "pkce.code.challenge.method": "S256"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": false,
+                "nodeReRegistrationTimeout": 0,
+                "protocolMappers": [
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              },
+              {
+                "clientId": "sequence",
+                "name": "Sequence",
+                "description": "Client for the Alice persona's access ",
+                "rootUrl": "",
+                "adminUrl": "",
+                "baseUrl": "/",
+                "surrogateAuthRequired": false,
+                "enabled": true,
+                "alwaysDisplayInConsole": false,
+                "clientAuthenticatorType": "client-secret",
+                "secret": "secret",
+                "redirectUris": [
+                  "/*"
+                ],
+                "webOrigins": [
+                  "*"
+                ],
+                "notBefore": 0,
+                "bearerOnly": false,
+                "consentRequired": false,
+                "standardFlowEnabled": true,
+                "implicitFlowEnabled": false,
+                "directAccessGrantsEnabled": false,
+                "serviceAccountsEnabled": true,
+                "publicClient": false,
+                "frontchannelLogout": true,
+                "protocol": "openid-connect",
+                "attributes": {
+                  "oidc.ciba.grant.enabled": "false",
+                  "client.secret.creation.time": "1716216657",
+                  "backchannel.logout.session.required": "true",
+                  "post.logout.redirect.uris": "/*",
+                  "display.on.consent.screen": "false",
+                  "oauth2.device.authorization.grant.enabled": "false",
+                  "backchannel.logout.revoke.offline.tokens": "false"
+                },
+                "authenticationFlowBindingOverrides": {},
+                "fullScopeAllowed": true,
+                "nodeReRegistrationTimeout": -1,
+                "protocolMappers": [
+                  {
+                    "name": "Client IP Address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientAddress",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientAddress",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client ID",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "client_id",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "client_id",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "Client Host",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usersessionmodel-note-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.session.note": "clientHost",
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "clientHost",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ],
+                "defaultClientScopes": [
+                  "web-origins",
+                  "acr",
+                  "roles",
+                  "profile",
+                  "email"
+                ],
+                "optionalClientScopes": [
+                  "address",
+                  "phone",
+                  "offline_access",
+                  "microprofile-jwt"
+                ]
+              }
+            ],
+            "clientScopes": [
+              {
+                "name": "roles",
+                "description": "OpenID Connect scope for add user roles to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${rolesScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "realm roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "realm_access.roles",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "audience resolve",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-audience-resolve-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "client roles",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-client-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "access.token.claim": "true",
+                      "claim.name": "resource_access.${client_id}.roles",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${profileScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "family name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "lastName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "family_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "gender",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "gender",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "gender",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "profile",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "profile",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "profile",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "website",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "website",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "website",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "full name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-full-name-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true",
+                      "userinfo.token.claim": "true"
+                    }
+                  },
+                  {
+                    "name": "birthdate",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "birthdate",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "birthdate",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "nickname",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "nickname",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "nickname",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "username",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "preferred_username",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "updated at",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "updatedAt",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "updated_at",
+                      "jsonType.label": "long"
+                    }
+                  },
+                  {
+                    "name": "locale",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "locale",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "locale",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "zoneinfo",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "zoneinfo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "zoneinfo",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "given name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "firstName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "given_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "middle name",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "middleName",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "middle_name",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "picture",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "picture",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "picture",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "offline_access",
+                "description": "OpenID Connect built-in scope: offline_access",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "consent.screen.text": "${offlineAccessScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                }
+              },
+              {
+                "name": "email",
+                "description": "OpenID Connect built-in scope: email",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${emailScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "email verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-property-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "emailVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  },
+                  {
+                    "name": "email",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "email",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "email",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "microprofile-jwt",
+                "description": "Microprofile - JWT built-in scope",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "groups",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-realm-role-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "multivalued": "true",
+                      "user.attribute": "foo",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "groups",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "upn",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "username",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "upn",
+                      "jsonType.label": "String"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "role_list",
+                "description": "SAML role list",
+                "protocol": "saml",
+                "attributes": {
+                  "consent.screen.text": "${samlRoleListScopeConsentText}",
+                  "display.on.consent.screen": "true"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "role list",
+                    "protocol": "saml",
+                    "protocolMapper": "saml-role-list-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "single": "false",
+                      "attribute.nameformat": "Basic",
+                      "attribute.name": "Role"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "acr",
+                "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "acr loa level",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-acr-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "id.token.claim": "true",
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "address",
+                "description": "OpenID Connect built-in scope: address",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${addressScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "address",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-address-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "user.attribute.formatted": "formatted",
+                      "user.attribute.country": "country",
+                      "introspection.token.claim": "true",
+                      "user.attribute.postal_code": "postal_code",
+                      "userinfo.token.claim": "true",
+                      "user.attribute.street": "street",
+                      "id.token.claim": "true",
+                      "user.attribute.region": "region",
+                      "access.token.claim": "true",
+                      "user.attribute.locality": "locality"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "phone",
+                "description": "OpenID Connect built-in scope: phone",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "true",
+                  "display.on.consent.screen": "true",
+                  "consent.screen.text": "${phoneScopeConsentText}"
+                },
+                "protocolMappers": [
+                  {
+                    "name": "phone number",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumber",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number",
+                      "jsonType.label": "String"
+                    }
+                  },
+                  {
+                    "name": "phone number verified",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-usermodel-attribute-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "userinfo.token.claim": "true",
+                      "user.attribute": "phoneNumberVerified",
+                      "id.token.claim": "true",
+                      "access.token.claim": "true",
+                      "claim.name": "phone_number_verified",
+                      "jsonType.label": "boolean"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "web-origins",
+                "description": "OpenID Connect scope for add allowed web origins to the access token",
+                "protocol": "openid-connect",
+                "attributes": {
+                  "include.in.token.scope": "false",
+                  "display.on.consent.screen": "false",
+                  "consent.screen.text": ""
+                },
+                "protocolMappers": [
+                  {
+                    "name": "allowed web origins",
+                    "protocol": "openid-connect",
+                    "protocolMapper": "oidc-allowed-origins-mapper",
+                    "consentRequired": false,
+                    "config": {
+                      "introspection.token.claim": "true",
+                      "access.token.claim": "true"
+                    }
+                  }
+                ]
+              }
+            ],
+            "defaultDefaultClientScopes": [
+              "role_list",
+              "profile",
+              "email",
+              "roles",
+              "web-origins",
+              "acr"
+            ],
+            "defaultOptionalClientScopes": [
+              "offline_access",
+              "address",
+              "phone",
+              "microprofile-jwt"
+            ],
+            "browserSecurityHeaders": {
+              "contentSecurityPolicyReportOnly": "",
+              "xContentTypeOptions": "nosniff",
+              "referrerPolicy": "no-referrer",
+              "xRobotsTag": "none",
+              "xFrameOptions": "SAMEORIGIN",
+              "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+              "xXSSProtection": "1; mode=block",
+              "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+            },
+            "smtpServer": {},
+            "eventsEnabled": false,
+            "eventsListeners": [
+              "jboss-logging"
+            ],
+            "enabledEventTypes": [],
+            "adminEventsEnabled": false,
+            "adminEventsDetailsEnabled": false,
+            "identityProviders": [],
+            "identityProviderMappers": [],
+            "components": {
+              "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+                {
+                  "name": "Consent Required",
+                  "providerId": "consent-required",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Full Scope Disabled",
+                  "providerId": "scope",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {}
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Client Scopes",
+                  "providerId": "allowed-client-templates",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allow-default-scopes": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "oidc-address-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-full-name-mapper",
+                      "saml-role-list-mapper",
+                      "saml-user-property-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Allowed Protocol Mapper Types",
+                  "providerId": "allowed-protocol-mappers",
+                  "subType": "authenticated",
+                  "subComponents": {},
+                  "config": {
+                    "allowed-protocol-mapper-types": [
+                      "saml-user-property-mapper",
+                      "oidc-address-mapper",
+                      "saml-role-list-mapper",
+                      "oidc-full-name-mapper",
+                      "oidc-usermodel-property-mapper",
+                      "saml-user-attribute-mapper",
+                      "oidc-sha256-pairwise-sub-mapper",
+                      "oidc-usermodel-attribute-mapper"
+                    ]
+                  }
+                },
+                {
+                  "name": "Trusted Hosts",
+                  "providerId": "trusted-hosts",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "host-sending-registration-request-must-match": [
+                      "true"
+                    ],
+                    "client-uris-must-match": [
+                      "true"
+                    ]
+                  }
+                },
+                {
+                  "name": "Max Clients Limit",
+                  "providerId": "max-clients",
+                  "subType": "anonymous",
+                  "subComponents": {},
+                  "config": {
+                    "max-clients": [
+                      "200"
+                    ]
+                  }
+                }
+              ],
+              "org.keycloak.keys.KeyProvider": [
+                {
+                  "name": "aes-generated",
+                  "providerId": "aes-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-generated",
+                  "providerId": "rsa-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ]
+                  }
+                },
+                {
+                  "name": "rsa-enc-generated",
+                  "providerId": "rsa-enc-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "RSA-OAEP"
+                    ]
+                  }
+                },
+                {
+                  "name": "hmac-generated-hs512",
+                  "providerId": "hmac-generated",
+                  "subComponents": {},
+                  "config": {
+                    "priority": [
+                      "100"
+                    ],
+                    "algorithm": [
+                      "HS512"
+                    ]
+                  }
+                }
+              ]
+            },
+            "internationalizationEnabled": false,
+            "supportedLocales": [],
+            "authenticationFlows": [
+              {
+                "alias": "Account verification options",
+                "description": "Method with which to verity the existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-email-verification",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Verify Existing Account by Re-authentication",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Browser - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Direct Grant - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "First broker login - Conditional OTP",
+                "description": "Flow to determine if the OTP is required for the authentication",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-otp-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Handle Existing Account",
+                "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-confirm-link",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Account verification options",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Reset - Conditional OTP",
+                "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "conditional-user-configured",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-otp",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "User creation or linking",
+                "description": "Flow for the existing/non-existing user alternatives",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "create unique user config",
+                    "authenticator": "idp-create-user-if-unique",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Handle Existing Account",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "Verify Existing Account by Re-authentication",
+                "description": "Reauthentication of existing account",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "idp-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "First broker login - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "browser",
+                "description": "browser based authentication",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-cookie",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "auth-spnego",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "identity-provider-redirector",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 25,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "forms",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "clients",
+                "description": "Base authentication for clients",
+                "providerId": "client-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "client-secret",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-secret-jwt",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "client-x509",
+                    "authenticatorFlow": false,
+                    "requirement": "ALTERNATIVE",
+                    "priority": 40,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "direct grant",
+                "description": "OpenID Connect Resource Owner Grant",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "direct-grant-validate-username",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "direct-grant-validate-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 30,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Direct Grant - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "docker auth",
+                "description": "Used by Docker clients to authenticate against the IDP",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "docker-http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "first broker login",
+                "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticatorConfig": "review profile config",
+                    "authenticator": "idp-review-profile",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "User creation or linking",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "forms",
+                "description": "Username, password, otp and other auth forms.",
+                "providerId": "basic-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "auth-username-password-form",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 20,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Browser - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration",
+                "description": "registration flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-page-form",
+                    "authenticatorFlow": true,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": true,
+                    "flowAlias": "registration form",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "registration form",
+                "description": "registration form",
+                "providerId": "form-flow",
+                "topLevel": false,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "registration-user-creation",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-password-action",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 50,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-recaptcha-action",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 60,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "registration-terms-and-conditions",
+                    "authenticatorFlow": false,
+                    "requirement": "DISABLED",
+                    "priority": 70,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "reset credentials",
+                "description": "Reset credentials for a user if they forgot their password or something",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "reset-credentials-choose-user",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-credential-email",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 20,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticator": "reset-password",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 30,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  },
+                  {
+                    "authenticatorFlow": true,
+                    "requirement": "CONDITIONAL",
+                    "priority": 40,
+                    "autheticatorFlow": true,
+                    "flowAlias": "Reset - Conditional OTP",
+                    "userSetupAllowed": false
+                  }
+                ]
+              },
+              {
+                "alias": "saml ecp",
+                "description": "SAML ECP Profile Authentication Flow",
+                "providerId": "basic-flow",
+                "topLevel": true,
+                "builtIn": true,
+                "authenticationExecutions": [
+                  {
+                    "authenticator": "http-basic-authenticator",
+                    "authenticatorFlow": false,
+                    "requirement": "REQUIRED",
+                    "priority": 10,
+                    "autheticatorFlow": false,
+                    "userSetupAllowed": false
+                  }
+                ]
+              }
+            ],
+            "authenticatorConfig": [
+              {
+                "alias": "create unique user config",
+                "config": {
+                  "require.password.update.after.registration": "false"
+                }
+              },
+              {
+                "alias": "review profile config",
+                "config": {
+                  "update.profile.on.first.login": "missing"
+                }
+              }
+            ],
+            "requiredActions": [
+              {
+                "alias": "CONFIGURE_TOTP",
+                "name": "Configure OTP",
+                "providerId": "CONFIGURE_TOTP",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 10,
+                "config": {}
+              },
+              {
+                "alias": "TERMS_AND_CONDITIONS",
+                "name": "Terms and Conditions",
+                "providerId": "TERMS_AND_CONDITIONS",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 20,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PASSWORD",
+                "name": "Update Password",
+                "providerId": "UPDATE_PASSWORD",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 30,
+                "config": {}
+              },
+              {
+                "alias": "UPDATE_PROFILE",
+                "name": "Update Profile",
+                "providerId": "UPDATE_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 40,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_EMAIL",
+                "name": "Verify Email",
+                "providerId": "VERIFY_EMAIL",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 50,
+                "config": {}
+              },
+              {
+                "alias": "delete_account",
+                "name": "Delete Account",
+                "providerId": "delete_account",
+                "enabled": false,
+                "defaultAction": false,
+                "priority": 60,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register",
+                "name": "Webauthn Register",
+                "providerId": "webauthn-register",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 70,
+                "config": {}
+              },
+              {
+                "alias": "webauthn-register-passwordless",
+                "name": "Webauthn Register Passwordless",
+                "providerId": "webauthn-register-passwordless",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 80,
+                "config": {}
+              },
+              {
+                "alias": "VERIFY_PROFILE",
+                "name": "Verify Profile",
+                "providerId": "VERIFY_PROFILE",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 90,
+                "config": {}
+              },
+              {
+                "alias": "delete_credential",
+                "name": "Delete Credential",
+                "providerId": "delete_credential",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 100,
+                "config": {}
+              },
+              {
+                "alias": "update_user_locale",
+                "name": "Update User Locale",
+                "providerId": "update_user_locale",
+                "enabled": true,
+                "defaultAction": false,
+                "priority": 1000,
+                "config": {}
+              }
+            ],
+            "browserFlow": "browser",
+            "registrationFlow": "registration",
+            "directGrantFlow": "direct grant",
+            "resetCredentialsFlow": "reset credentials",
+            "clientAuthenticationFlow": "clients",
+            "dockerAuthenticationFlow": "docker auth",
+            "firstBrokerLoginFlow": "first broker login",
+            "attributes": {
+              "cibaBackchannelTokenDeliveryMode": "poll",
+              "cibaAuthRequestedUserHint": "login_hint",
+              "oauth2DevicePollingInterval": "5",
+              "clientOfflineSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.import-checksum-default": "4ef043b20756896bb8cc0e6a2503c775afa2c158f87ea417dd8d67be910fc3bb",
+              "clientSessionIdleTimeout": "0",
+              "clientOfflineSessionIdleTimeout": "0",
+              "cibaInterval": "5",
+              "realmReusableOtpCode": "false",
+              "cibaExpiresIn": "120",
+              "oauth2DeviceCodeLifespan": "600",
+              "parRequestUriLifespan": "60",
+              "clientSessionMaxLifespan": "0",
+              "de.adorsys.keycloak.config.state-default-clients-0": "[\"sequence\"]"
+            },
+            "keycloakVersion": "24.0.4",
+            "userManagedAccessAllowed": false,
+            "clientProfiles": {
+              "profiles": []
+            },
+            "clientPolicies": {
+              "policies": []
+            }
+          }

--- a/charts/sqnc-attachment-api/ci/minio-values.yaml
+++ b/charts/sqnc-attachment-api/ci/minio-values.yaml
@@ -42,15 +42,14 @@ identity:
   postgresql:
     nameOverride: postgresql-identity
 ipfs:
+  enabled: false
+minio:
   enabled: true
-  sqncNode:
-    enabled: false
-  externalSqncNode:
-    host: attachment-node
-    port: 9944
-  service:
-    ports:
-      http: 5001
+  persistence:
+    size: 1Gi
+storageBackend:
+  mode: S3
+  protocol: http
 keycloak:
   enabled: true
   fullnameOverride: attachment-keycloak

--- a/charts/sqnc-attachment-api/templates/deployment.yaml
+++ b/charts/sqnc-attachment-api/templates/deployment.yaml
@@ -174,10 +174,63 @@ spec:
                 secretKeyRef:
                   name: {{ include "sqnc-attachment-api.databaseSecretName" . }}
                   key: {{ include "sqnc-attachment-api.databaseSecretPasswordKey" . }}
+            - name: STORAGE_BACKEND_MODE
+              value: {{ .Values.storageBackend.mode }}
+            {{- if eq .Values.storageBackend.mode "IPFS" }}
             - name: IPFS_HOST
               value: {{ template "sqnc-attachment-api.sqncIpfsHost" . }}
             - name: IPFS_PORT
               value: {{ template "sqnc-attachment-api.sqncIpfsPort" . }}
+            {{- end }}
+            {{- if  or (eq .Values.storageBackend.mode "AZURE") (eq .Values.storageBackend.mode "S3") }}
+            - name: STORAGE_BACKEND_HOST
+              value: {{ template "sqnc-attachment-api.storageBackendHost" . }}
+            - name: STORAGE_BACKEND_PORT
+              value: {{ template "sqnc-attachment-api.storageBackendPort" . }}
+            - name: STORAGE_BACKEND_BUCKET_NAME
+              value: {{ .Values.storageBackend.bucketName }}
+            - name: STORAGE_BACKEND_PROTOCOL
+              value: {{ .Values.storageBackend.protocol }}
+            {{- if eq .Values.storageBackend.mode "S3" }}
+            {{- if .Values.storageBackend.s3Region }}
+            - name: STORAGE_BACKEND_S3_REGION
+              value: {{ .Values.storageBackend.s3Region }}
+            {{- end }}
+            - name: STORAGE_BACKEND_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sqnc-attachment-api.s3SecretName" . }}
+                  key: {{ include "sqnc-attachment-api.s3AccessKeyIdKey" . }}
+            - name: STORAGE_BACKEND_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sqnc-attachment-api.s3SecretName" . }}
+                  key: {{ include "sqnc-attachment-api.s3SecretAccessKeyKey" . }}
+            {{- end }}
+            {{- if eq .Values.storageBackend.mode "AZURE" }}
+            {{- if .Values.storageBackend.blobDomain }}
+            - name: STORAGE_BACKEND_BLOB_DOMAIN
+              value: {{ .Values.storageBackend.blobDomain }}
+            {{- end}}
+            {{- if .Values.azurite.enabled }}
+            - name: STORAGE_BACKEND_ACCOUNT_NAME
+              value: "devstoreaccount1"
+            - name: STORAGE_BACKEND_ACCOUNT_SECRET
+              value: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+            {{- else }}
+            - name: STORAGE_BACKEND_ACCOUNT_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sqnc-attachment-api.azureSecretName" . }}
+                  key: {{ include "sqnc-attachment-api.azureAccountNameKey" . }}
+            - name: STORAGE_BACKEND_ACCOUNT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sqnc-attachment-api.azureSecretName" . }}
+                  key: {{ include "sqnc-attachment-api.azureAccountKeyKey" . }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             - name: IDENTITY_SERVICE_HOST
               value: {{ template "sqnc-attachment-api.sqncIdentityHost" . }}
             - name: IDENTITY_SERVICE_PORT
@@ -271,9 +324,8 @@ spec:
         {{- if .Values.extraVolumes }}
         {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}
-        - name: idp-credentials
         {{- if .Values.idpCredentialsSecret.enabled }}
-        {{- include "sqnc-attachment-api.validateValues.idpCredentials" . | nindent 8 }}
+        - name: idp-credentials
           secret:
             secretName: {{ .Values.idpCredentialsSecret.name }}
         {{- end }}

--- a/charts/sqnc-attachment-api/templates/ingress.yaml
+++ b/charts/sqnc-attachment-api/templates/ingress.yaml
@@ -33,9 +33,7 @@ spec:
           {{- end }}
           {{- range .Values.ingress.paths }}
           - path: {{ .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
           {{- end }}
     {{- end }}
@@ -48,9 +46,7 @@ spec:
           {{- end }}
           {{- range .paths }}
           - path: {{ .path }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: {{ default "ImplementationSpecific" .pathType }}
-            {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "common.names.fullname" $) "servicePort" "http" "context" $) | nindent 14 }}
           {{- end }}
     {{- end }}

--- a/charts/sqnc-attachment-api/templates/secret-azure-creds.yaml
+++ b/charts/sqnc-attachment-api/templates/secret-azure-creds.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq .Values.storageBackend.mode "AZURE") (not .Values.azurite.enabled) (not .Values.storageBackend.existingAzureSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ printf "%s-azure-creds" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+    namespace: {{ .Release.Namespace | quote }}
+    labels: {{- include "common.labels.standard" . | nindent 4 }}
+        app.kubernetes.io/component: sqnc-attachment-api
+        {{- if .Values.commonLabels }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+        {{- end }}
+    {{- if .Values.commonAnnotations }}
+    annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+    accountName: {{ .Values.storageBackend.accountName | b64enc | quote }}
+    accountKey: {{ .Values.storageBackend.accountKey | b64enc | quote }}
+{{- end }}

--- a/charts/sqnc-attachment-api/templates/secret-s3-creds.yaml
+++ b/charts/sqnc-attachment-api/templates/secret-s3-creds.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq .Values.storageBackend.mode "S3") (not (or .Values.minio.enabled .Values.storageBackend.existingS3Secret)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-s3-creds" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: sqnc-attachment-api
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.commonAnnotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  accessKeyId: {{ .Values.storageBackend.accessKeyId | b64enc | quote }}
+  secretAccessKey: {{ .Values.storageBackend.secretAccessKey | b64enc | quote }}
+{{- end }}

--- a/charts/sqnc-attachment-api/values.yaml
+++ b/charts/sqnc-attachment-api/values.yaml
@@ -374,13 +374,10 @@ extraEnvVarsCM: ""
 extraEnvVarsSecret: ""
 ## @param extraVolumes Optionally specify extra list of additional volumes for the sqnc-attachment-api pod(s)
 ##
-extraVolumes:
-  - name: realm-volume
-    configMap:
-      name: keycloak-realms
-extraVolumeMounts:
-  - mountPath: /opt/bitnami/keycloak/data/import
-    name: realm-volume
+extraVolumes: []
+## @param extraVolumeMounts Optionally specify extra list of additional volumeMounts for the sqnc-attachment-api container(s)
+##
+extraVolumeMounts: []
 ## @param sidecars Add additional sidecar containers to the sqnc-attachment-api pod(s)
 ## e.g:
 ## sidecars:
@@ -692,14 +689,10 @@ node:
   ##
   fullnameOverride: ""
 
-## @section SQNC-Ipfs parameters
-## @param externalSqncIpfs.host External SQNC-Ipfs hostname
-##
-externalSqncIpfs:
-  host: ""
-  ## @param externalSqncIpfs.port External SQNC-Ipfs port
-  ##
-  port: ""
+## @section Keycloak Parameters
+keycloak:
+  ## @param keycloak.enabled Enable Keycloak subchart
+  enabled: false
 
 ## @section SQNC-Identity-Service parameters
 ## @param externalSqncIdentity.host External SQNC-Identity-Service hostname
@@ -710,19 +703,67 @@ externalSqncIdentity:
   ##
   port: ""
 
-## @section Keycloak Parameters
-keycloak:
-  ## @param keycloak.enabled Enable Keycloak subchart
-  enabled: false
-
 ## @section SQNC Identity Service Parameters
 identity:
   ## @param identity.enabled Enable sqnc-identity-service subchart
   enabled: false
 
-## @section SQNC Ipfs Parameters
+## @section Backend Storage Parameters
+## @param storageBackend.mode Storage mode to use, choice of IPFS, AZURE or S3
+storageBackend:
+  mode: IPFS
+  ## @param storageBackend.accessKeyId The access key ID to use for the s3 storageBackend
+  accessKeyId: ""
+  ## @param storageBackend.secretAccessKey The secret access key to use for the s3 storageBackend
+  secretAccessKey: ""
+  ## @param storageBackend.s3Region The AWS region to use with Amazon S3
+  s3Region: ""
+  ## @param storageBackend.bucketName The bucket or storageContainer name to use
+  bucketName: ""
+  ## @param storageBackend.protocol The Protocol to use for accessing the storage backend, options are http or https
+  protocol: "https"
+  ## @param storageBackend.existingS3Secret The existing Secret to use for the s3 Credentials
+  existingS3Secret: ""
+  ## @param storageBackend.existingS3SecretAccessKeyKey The key to use for the S3 SecretaccessKey
+  existingS3SecretAccessKeyKey: "secretAccessKey"
+  ## @param storageBackend.existingS3AccessKeyIdKey The key to use for the S3 AccessKeyId
+  existingS3AccessKeyIdKey: "accessKeyId"
+  ## @param storageBackend.accountName The Account Name to use with Azure
+  accountName: ""
+  ## @param storageBackend.accountKey The Account Key to use with Azure
+  accountKey: ""
+  ## @param storageBackend.blobDomain The BlobDomain to use with Azure
+  blobDomain: ""
+  ## @param storageBackend.existingAzureSecret The existing secret to use for the Azure Credentials
+  existingAzureSecret: ""
+  ## @param storageBackend.existingAzureAccountNameKey The key to use for the Azure AccountName
+  existingAzureAccountNameKey: "accountName"
+  ## @param storageBackend.existingAzureAccountKeyKey The key to use for the Azure AccountKey
+  existingAzureAccountKeyKey: "accountKey"
+## @param externalStorageBackend.host
+externalStorageBackend:
+  host: ""
+  ## @param externalStorageBackend.port
+  port: ""
+
+## @param externalSqncIpfs.host External SQNC-Ipfs hostname
+##
+externalSqncIpfs:
+  host: ""
+  ## @param externalSqncIpfs.port External SQNC-Ipfs port
+  ##
+  port: ""
+
 ipfs:
   ## @param ipfs.enabled Enable sqnc-ipfs subchart
+  enabled: false
+
+minio:
+  ## @param minio.enabled Enable minio subchart
+  enabled: false
+
+azurite:
+  ## @param azurite.enabled Enable the azurite subchart
   enabled: false
 
 ## @section Helm test parameters


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Feature

## Linked tickets

SQNC-185

## High level description

Adds multiple storage backends to the attachment service.

## Detailed description

Adds Minio as a subchart
Adds Azurite as a subchart
Adds logic to switch envars depending on which storageBackend is set
Adds helpers to deal with correct secret values being used


## Describe alternatives you've considered

N/A

## Operational impact

<!--- A description of any operational considerations associated with the change. Is there anything in particular we should be looking at when deploying the change to make sure it is working as intended. If something goes wrong will any special actions be needed to revert the change. -->

## Additional context

<!-- Add any other context or screenshots about the feature request here. -->
