### PR TITLE
Add CNPG cluster to Veritable charts

### DIFF
--- a/charts/veritable-cloudagent/Chart.lock
+++ b/charts/veritable-cloudagent/Chart.lock
@@ -1,9 +1,15 @@
 dependencies:
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.26.0
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.3.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.0.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
   version: 2.24.0
-digest: sha256:28d29bb12645ea4843f40fa85b23c06096a192ad36ebc9cc91c1571bfeee59ef
-generated: "2024-10-03T10:17:41.385185615Z"
+digest: sha256:43ef5d9e5421b2906da0ee853909c565a175a2963e5da62e2339e86b48d33634
+generated: "2025-10-03T10:07:15.216603+01:00"

--- a/charts/veritable-cloudagent/Chart.yaml
+++ b/charts/veritable-cloudagent/Chart.yaml
@@ -5,15 +5,23 @@ apiVersion: v2
 # renovate: image=digicatapult/veritable-cloudagent
 appVersion: v0.15.3
 dependencies:
+  - name: cloudnative-pg
+    repository: https://cloudnative-pg.github.io/charts
+    version: 0.26.0
+  - alias: cnpg
+    condition: cnpg.enabled
+    name: cluster
+    repository: https://cloudnative-pg.github.io/charts
+    version: 0.3.1
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
-    version: 16.x
+    version: 16.0.0
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 2.x.x
+    version: 2.24.0
 description: The veritable-cloudagent is a component of the veritable distributed identity system.
 home: https://github.com/digicatapult/veritable-documentation
 icon: https://raw.githubusercontent.com/digicatapult/veritable-documentation/main/assets/icon.png
@@ -26,4 +34,4 @@ maintainers:
 name: veritable-cloudagent
 sources:
   - https://github.com/digicatapult/veritable-cloudagent
-version: 2.4.50
+version: 3.0.0

--- a/charts/veritable-cloudagent/README.md
+++ b/charts/veritable-cloudagent/README.md
@@ -6,7 +6,9 @@ The veritable-cloudagent is a component of the Sequence (veritable) ledger-based
 
 ```console
 $ helm repo add digicatapult https://digicatapult.github.io/helm-charts
-$ helm install my-release digicatapult/veritable-cloudagent
+$ helm repo add cnpg https://cloudnative-pg.github.io/charts
+$ helm upgrade --install my-release --namespace default cnpg/cloudnative-pg
+$ helm upgrade --install my-release digicatapult/veritable-cloudagent
 ```
 
 ## Introduction
@@ -25,7 +27,9 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add digicatapult https://digicatapult.github.io/helm-charts
-$ helm install my-release digicatapult/veritable-cloudagent
+$ helm repo add cnpg https://cloudnative-pg.github.io/charts
+$ helm upgrade --install my-release --namespace default cnpg/cloudnative-pg
+$ helm upgrade --install my-release digicatapult/veritable-cloudagent
 ```
 
 The command deploys veritable-cloudagent on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -342,6 +346,23 @@ The command removes all the Kubernetes components associated with the chart and 
 | `externalDatabase.existingSecret`                    | Name of an existing secret resource containing the database credentials  | `""`                              |
 | `externalDatabase.existingSecretPasswordKey`         | Name of an existing secret key containing the non-root credentials       | `""`                              |
 | `externalDatabase.existingSecretPostgresPasswordKey` | Name of an existing secret key containing the admin credentials          | `""`                              |
+
+### cloudnative-pg (CNPG) cluster
+
+| Name                                 | Description                                                                                             | Value        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------------ |
+| `cnpg.enabled`                       | Enable the cloudnative-pg cluster                                                                       | `true`       |
+| `cnpg.mode`                          | Cluster mode of operation ("standalone", "replica", or "recovery")                                      | `standalone` |
+| `cnpg.type`                          | Type of backend ("postgresql" is recommended)                                                           | `postgresql` |
+| `cnpg.version.postgresql`            | Major PostgreSQL version to use                                                                         | `17`         |
+| `cnpg.cluster.imageName`             | Long-form PostgreSQL GHCR image ID                                                                      | `""`         |
+| `cnpg.cluster.initdb`                | Details of the database object being created                                                            | `{}`         |
+| `cnpg.cluster.initdb.secret.name`    | Secret name for the database owner (expects "username"/"password" keys within secret)                   |              |
+| `cnpg.cluster.instances`             | Number of database replicas                                                                             | `1`          |
+| `cnpg.cluster.storage.size`          | Instance storage capacity                                                                               | `5Gi`        |
+| `cnpg.cluster.storage.storageClass`  | Storage class                                                                                           | `""`         |
+| `cnpg.cluster.enableSuperuserAccess` | Permit superuser access                                                                                 | `true`       |
+| `cnpg.cluster.superuserSecret`       | Name of the superuser's secret (expects "pgpass"; uses a randomised password if enabled and left blank) |              |
 
 ## Configuration and installation details
 

--- a/charts/veritable-cloudagent/ci/ct-values.yaml
+++ b/charts/veritable-cloudagent/ci/ct-values.yaml
@@ -1,1 +1,5 @@
+global:
+  postgresql:
+    auth:
+      password: password
 isNginxIngressController: true

--- a/charts/veritable-cloudagent/templates/secret-cnpg-app.yaml
+++ b/charts/veritable-cloudagent/templates/secret-cnpg-app.yaml
@@ -1,11 +1,13 @@
-{{- if not (or .Values.cnpg.enabled .Values.externalDatabase.existingSecret) }}
+{{- if .Values.cnpg.enabled }}
+{{- $initdb := .Values.cnpg.cluster.initdb | default dict }}
+{{- if (not $initdb.secret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-cnpg-app" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: veritable-ui
+    app.kubernetes.io/component: veritable-cloudagent
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -14,6 +16,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  postgres-password: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  username: {{ $initdb.owner | b64enc | quote }}
+  password: {{ randAlphaNum 36 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/veritable-cloudagent/templates/secret-cnpg-superuser.yaml
+++ b/charts/veritable-cloudagent/templates/secret-cnpg-superuser.yaml
@@ -1,11 +1,13 @@
-{{- if not (or .Values.cnpg.enabled .Values.externalDatabase.existingSecret) }}
+{{- if .Values.cnpg.enabled }}
+{{- $cluster := .Values.cnpg.cluster | default dict }}
+{{- if and (not $cluster.superuserSecret) $cluster.enableSuperuserAccess -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-cnpg-superuser" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: veritable-ui
+    app.kubernetes.io/component: veritable-cloudagent
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -14,6 +16,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  postgres-password: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  username: {{ "postgres" | b64enc | quote }}
+  password: {{ randAlphaNum 36 | b64enc | quote }}
+  pgpass: {{ randAlphaNum 36 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/veritable-cloudagent/templates/secret-externaldb.yaml
+++ b/charts/veritable-cloudagent/templates/secret-externaldb.yaml
@@ -1,4 +1,4 @@
-{{- if not (or .Values.postgresql.enabled .Values.externalDatabase.existingSecret) }}
+{{- if not (or .Values.cnpg.enabled .Values.externalDatabase.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/veritable-cloudagent/templates/statefulset.yaml
+++ b/charts/veritable-cloudagent/templates/statefulset.yaml
@@ -67,9 +67,9 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if or .Values.initContainers .Values.ipfs.initConfig (and (not .Values.postgresql.enabled) .Values.externalDatabase.create) }}
+      {{- if or .Values.initContainers .Values.ipfs.initConfig (and (not .Values.cnpg.enabled) .Values.externalDatabase.create) }}
       initContainers:
-        {{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.create }}
+        {{- if and (not .Values.cnpg.enabled) .Values.externalDatabase.create }}
         - name: database-create
           image: {{ template "veritable-cloudagent.initDbCreate.image" . }}
           imagePullPolicy: {{ .Values.initDbCreate.image.pullPolicy }}

--- a/charts/veritable-cloudagent/values.yaml
+++ b/charts/veritable-cloudagent/values.yaml
@@ -1067,3 +1067,56 @@ externalDatabase:
   existingSecret: ""
   existingSecretPasswordKey: ""
   existingSecretPostgresPasswordKey: ""
+
+## @section cloudnative-pg (CNPG) cluster
+##
+## Ensure that the CNPG operator CRDs have already been installed before enabling.
+## https://github.com/cloudnative-pg/charts
+##
+## A comprehensive list of CNPG cluster values can be found here:
+## https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/values.yaml
+##
+## @param cnpg.enabled Enable the cloudnative-pg cluster
+## @param cnpg.mode Cluster mode of operation ("standalone", "replica", or "recovery")
+## @param cnpg.type Type of backend ("postgresql" is recommended)
+## @param cnpg.version.postgresql Major PostgreSQL version to use
+##
+## Nb. To automatically perform a major version upgrade of the PostgreSQL instances,
+## increase this value incrementally to arrive at the target version.
+##
+## @param cnpg.cluster.imageName Long-form PostgreSQL GHCR image ID
+## @param cnpg.cluster.initdb [object] Details of the database object being created
+## @extra cnpg.cluster.initdb.secret.name Secret name for the database owner (expects "username"/"password" keys within secret)
+## e.g.
+    # initdb:
+      # database: example
+      # owner: example-owner
+      # secret:
+        # name: example-cnpg-app
+      # options: []
+      # encoding: UTF8
+      # postInitSQL:
+      #   - CREATE EXTENSION IF NOT EXISTS vector;
+      # postInitApplicationSQL: []
+      # postInitTemplateSQL: []
+## @param cnpg.cluster.instances Number of database replicas
+## @param cnpg.cluster.storage.size Instance storage capacity
+## @param cnpg.cluster.storage.storageClass Storage class
+## @param cnpg.cluster.enableSuperuserAccess Permit superuser access
+## @extra cnpg.cluster.superuserSecret Name of the superuser's secret (expects "pgpass"; uses a randomised password if enabled and left blank)
+cnpg:
+  enabled: true
+  type: postgresql
+  version:
+    postgresql: "17"
+  mode: standalone
+  cluster:
+    imageName: ""
+    initdb:
+      database: veritable-cloudagent
+      owner: postgres
+    instances: 1
+    storage:
+      size: 5Gi
+      storageClass: ""
+    enableSuperuserAccess: true

--- a/charts/veritable-ui/Chart.lock
+++ b/charts/veritable-ui/Chart.lock
@@ -1,4 +1,10 @@
 dependencies:
+- name: cloudnative-pg
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.26.0
+- name: cluster
+  repository: https://cloudnative-pg.github.io/charts
+  version: 0.3.1
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.6.3
@@ -8,5 +14,5 @@ dependencies:
 - name: veritable-cloudagent
   repository: https://digicatapult.github.io/helm-charts
   version: 2.4.50
-digest: sha256:84cbf0b0875ce049824f4dab576db812890cc383bf4d3c0b8c4d69ca25ea9d09
-generated: "2025-09-30T23:12:05.163396278Z"
+digest: sha256:1b8759eb9a45efdb5f71f600edb83bfcf0b9e6f5547fb35f97969e36914a67d0
+generated: "2025-10-03T10:08:04.630866+01:00"

--- a/charts/veritable-ui/Chart.yaml
+++ b/charts/veritable-ui/Chart.yaml
@@ -5,6 +5,14 @@ apiVersion: v2
 # renovate: image=digicatapult/veritable-ui
 appVersion: v0.20.34
 dependencies:
+  - name: cloudnative-pg
+    repository: https://cloudnative-pg.github.io/charts
+    version: 0.26.0
+  - alias: cnpg
+    condition: cnpg.enabled
+    name: cluster
+    repository: https://cloudnative-pg.github.io/charts
+    version: 0.3.1
   - condition: postgresql.enabled
     name: postgresql
     repository: https://charts.bitnami.com/bitnami
@@ -30,4 +38,4 @@ maintainers:
 name: veritable-ui
 sources:
   - https://github.com/digicatapult/veritable-ui
-version: 1.4.41
+version: 2.0.0

--- a/charts/veritable-ui/README.md
+++ b/charts/veritable-ui/README.md
@@ -6,7 +6,9 @@ The veritable-ui is an UI for Veritable that manages connections. Utilizing TSOA
 
 ```console
 $ helm repo add digicatapult https://digicatapult.github.io/helm-charts
-$ helm install my-release digicatapult/veritable-ui
+$ helm repo add cnpg https://cloudnative-pg.github.io/charts
+$ helm upgrade --install my-release --namespace default cnpg/cloudnative-pg
+$ helm upgrade --install my-release digicatapult/veritable-ui
 ```
 
 ## Introduction
@@ -25,7 +27,9 @@ To install the chart with the release name `my-release`:
 
 ```console
 $ helm repo add digicatapult https://digicatapult.github.io/helm-charts
-$ helm install my-release digicatapult/veritable-ui
+$ helm repo add cnpg https://cloudnative-pg.github.io/charts
+$ helm upgrade --install my-release --namespace default cnpg/cloudnative-pg
+$ helm upgrade --install my-release digicatapult/veritable-ui
 ```
 
 The command deploys veritable-ui on the Kubernetes cluster in the default configuration. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -309,6 +313,23 @@ The command removes all the Kubernetes components associated with the chart and 
 | Name                     | Description                       | Value |
 | ------------------------ | --------------------------------- | ----- |
 | `externalCloudagent.url` | External veritable-cloudagent URL | `""`  |
+
+### cloudnative-pg (CNPG) cluster
+
+| Name                                 | Description                                                                                             | Value        |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------- | ------------ |
+| `cnpg.enabled`                       | Enable the cloudnative-pg cluster                                                                       | `true`       |
+| `cnpg.mode`                          | Cluster mode of operation ("standalone", "replica", or "recovery")                                      | `standalone` |
+| `cnpg.type`                          | Type of backend ("postgresql" is recommended)                                                           | `postgresql` |
+| `cnpg.version.postgresql`            | Major PostgreSQL version to use                                                                         | `17`         |
+| `cnpg.cluster.imageName`             | Long-form PostgreSQL GHCR image ID                                                                      | `""`         |
+| `cnpg.cluster.initdb`                | Details of the database object being created                                                            | `{}`         |
+| `cnpg.cluster.initdb.secret.name`    | Secret name for the database owner (expects "username"/"password" keys within secret)                   |              |
+| `cnpg.cluster.instances`             | Number of database replicas                                                                             | `1`          |
+| `cnpg.cluster.storage.size`          | Instance storage capacity                                                                               | `5Gi`        |
+| `cnpg.cluster.storage.storageClass`  | Storage class                                                                                           | `""`         |
+| `cnpg.cluster.enableSuperuserAccess` | Permit superuser access                                                                                 | `true`       |
+| `cnpg.cluster.superuserSecret`       | Name of the superuser's secret (expects "pgpass"; uses a randomised password if enabled and left blank) |              |
 
 ## Configuration and installation details
 

--- a/charts/veritable-ui/ci/ct-values.yaml
+++ b/charts/veritable-ui/ci/ct-values.yaml
@@ -1,3 +1,7 @@
+global:
+  postgresql:
+    auth:
+      password: password
 invitationPin:
   secret: blah
 cloudagent:

--- a/charts/veritable-ui/templates/_helpers.tpl
+++ b/charts/veritable-ui/templates/_helpers.tpl
@@ -166,81 +166,64 @@ Add environment variables to configure openCorporates API key secret values
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "veritable-ui.postgresql.fullname" -}}
-{{- include "common.names.dependency.fullname" (dict "chartName" "postgresql" "chartValues" .Values.postgresql "context" $) -}}
+{{- define "veritable-ui.cnpg.fullname" -}}
+{{- include "common.names.dependency.fullname" (dict "chartName" "cnpg" "chartValues" .Values.cnpg "context" $) -}}
 {{- end -}}
 
 {{/*
-Return the Postgresql hostname
+Return the CNPG hostname
 */}}
 {{- define "veritable-ui.databaseHost" -}}
-{{- ternary (include "veritable-ui.postgresql.fullname" .) .Values.externalDatabase.host .Values.postgresql.enabled | quote -}}
+{{- if .Values.cnpg.enabled -}}
+    {{- printf "%v-rw" (include "veritable-ui.cnpg.fullname" $) }}
+{{- else if .Values.externalDatabase.host -}}
+    {{- include "veritable-ui.cnpg.fullname" -}}
+{{- end -}}
 {{- end -}}
 
 
 {{/*
-Return the Postgresql port
+Return the CNPG port
 */}}
 {{- define "veritable-ui.databasePort" -}}
-{{- ternary "5432" .Values.externalDatabase.port .Values.postgresql.enabled | quote -}}
+{{- ternary "5432" .Values.externalDatabase.port .Values.cnpg.enabled | quote -}}
 {{- end -}}
 
 {{/*
-Return the Postgresql database name
+Return the CNPG database name
 */}}
 {{- define "veritable-ui.databaseName" -}}
-{{- if .Values.postgresql.enabled -}}
-    {{- if .Values.global.postgresql -}}
-        {{- if .Values.global.postgresql.auth -}}
-            {{- coalesce .Values.global.postgresql.auth.database .Values.postgresql.auth.database -}}
-        {{- else -}}
-            {{- .Values.postgresql.auth.database -}}
-        {{- end -}}
-    {{- else -}}
-        {{- .Values.postgresql.auth.database -}}
-    {{- end -}}
+{{- if .Values.cnpg.enabled -}}
+  {{- $initdb := .Values.cnpg.cluster.initdb | default dict }}
+  {{- $initdb.database -}}
 {{- else -}}
     {{- .Values.externalDatabase.database -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the Postgresql user
+Return the CNPG user
 */}}
 {{- define "veritable-ui.databaseUser" -}}
-{{- if .Values.postgresql.enabled -}}
-    {{- if .Values.global.postgresql -}}
-        {{- if .Values.global.postgresql.auth -}}
-            {{- coalesce .Values.global.postgresql.auth.username .Values.postgresql.auth.username -}}
-        {{- else -}}
-            {{- .Values.postgresql.auth.username -}}
-        {{- end -}}
-    {{- else -}}
-        {{- .Values.postgresql.auth.username -}}
-    {{- end -}}
+{{- if .Values.cnpg.enabled -}}
+  {{- $initdb := .Values.cnpg.cluster.initdb | default dict }}
+  {{- $initdb.owner -}}
 {{- else -}}
     {{- .Values.externalDatabase.user -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
-Return the PostgreSQL Secret Name
+Return the CNPG secret name
 */}}
 {{- define "veritable-ui.databaseSecretName" -}}
-{{- if .Values.postgresql.enabled -}}
-    {{- if .Values.global.postgresql -}}
-        {{- if .Values.global.postgresql.auth -}}
-            {{- if .Values.global.postgresql.auth.existingSecret -}}
-                {{- tpl .Values.global.postgresql.auth.existingSecret $ -}}
-            {{- else -}}
-                {{- default (include "veritable-ui.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
-            {{- end -}}
-        {{- else -}}
-            {{- default (include "veritable-ui.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
-        {{- end -}}
-    {{- else -}}
-        {{- default (include "veritable-ui.postgresql.fullname" .) (tpl .Values.postgresql.auth.existingSecret $) -}}
-    {{- end -}}
+{{- if .Values.cnpg.enabled -}}
+  {{- $secret := .Values.cnpg.cluster.initdb.secret | default dict }}
+  {{- if $secret.name -}}
+    {{- default (printf "%s-cnpg-app" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") (tpl $secret.name $) -}}
+  {{- else -}}
+    {{- printf "%s-cnpg-app" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" | quote -}}
+  {{- end -}}
 {{- else -}}
     {{- default (printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-") (tpl .Values.externalDatabase.existingSecret $) -}}
 {{- end -}}
@@ -250,7 +233,7 @@ Return the PostgreSQL Secret Name
 Add environment variables to configure database values
 */}}
 {{- define "veritable-ui.databaseSecretPasswordKey" -}}
-{{- if .Values.postgresql.enabled -}}
+{{- if .Values.cnpg.enabled -}}
     {{- print "password" -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
@@ -269,8 +252,8 @@ Add environment variables to configure database values
 Add environment variables to configure database values
 */}}
 {{- define "veritable-ui.databaseSecretPostgresPasswordKey" -}}
-{{- if .Values.postgresql.enabled -}}
-    {{- print "postgres-password" -}}
+{{- if .Values.cnpg.enabled -}}
+    {{- print "pgpass" -}}
 {{- else -}}
     {{- if .Values.externalDatabase.existingSecret -}}
         {{- if .Values.externalDatabase.existingSecretPostgresPasswordKey -}}
@@ -440,22 +423,22 @@ Compile all warnings into a single message, and call fail.
 
 {{/* Validate database name */}}
 {{- define "veritable-ui.validateValues.databaseName" -}}
-{{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.create -}}
+{{- if and (not .Values.cnpg.enabled) .Values.externalDatabase.create -}}
 {{- $db_name := (include "veritable-ui.databaseName" .) -}}
-{{- if not (regexMatch "^[a-zA-Z_]+$" $db_name) -}}
+{{- if not (regexMatch "^[-a-zA-Z_]+$" $db_name) -}}
 veritable-ui:
-    When creating a database the database name must consist of the characters a-z, A-Z and _ only
+    When creating a database the database name must consist of the characters a-z, A-Z, - and _ only
 {{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{/* Validate database username */}}
 {{- define "veritable-ui.validateValues.databaseUser" -}}
-{{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.create -}}
+{{- if and (not .Values.cnpg.enabled) .Values.externalDatabase.create -}}
 {{- $db_user := (include "veritable-ui.databaseUser" .) -}}
-{{- if not (regexMatch "^[a-zA-Z_]+$" $db_user) -}}
+{{- if not (regexMatch "^[-a-zA-Z_]+$" $db_user) -}}
 veritable-ui:
-    When creating a database the username must consist of the characters a-z, A-Z and _ only
+    When creating a database the username must consist of the characters a-z, A-Z, - and _ only
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/veritable-ui/templates/deployment.yaml
+++ b/charts/veritable-ui/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
-      {{- if or .Values.initContainers .Values.initDbMigrate.enabled .Values.initIssueancePolicy.enabled (and (not .Values.postgresql.enabled) .Values.externalDatabase.create) }}
+      {{- if or .Values.initContainers .Values.initDbMigrate.enabled .Values.initIssueancePolicy.enabled (and (not .Values.cnpg.enabled) .Values.externalDatabase.create) }}
       initContainers:
-        {{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.create }}
-        - name: database-create 
+        {{- if and (not .Values.cnpg.enabled) .Values.externalDatabase.create }}
+        - name: database-create
           image: {{ template "veritable-ui.initDbCreate.image" . }}
           imagePullPolicy: {{ .Values.initDbCreate.image.pullPolicy }}
           env:

--- a/charts/veritable-ui/templates/secret-cnpg-app.yaml
+++ b/charts/veritable-ui/templates/secret-cnpg-app.yaml
@@ -1,11 +1,13 @@
-{{- if not (or .Values.cnpg.enabled .Values.externalDatabase.existingSecret) }}
+{{- if .Values.cnpg.enabled }}
+{{- $initdb := .Values.cnpg.cluster.initdb | default dict }}
+{{- if (not $initdb.secret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-cnpg-app" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: veritable-ui
+    app.kubernetes.io/component: veritable-cloudagent
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -14,6 +16,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  postgres-password: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  username: {{ $initdb.owner | b64enc | quote }}
+  password: {{ randAlphaNum 36 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/veritable-ui/templates/secret-cnpg-superuser.yaml
+++ b/charts/veritable-ui/templates/secret-cnpg-superuser.yaml
@@ -1,11 +1,13 @@
-{{- if not (or .Values.cnpg.enabled .Values.externalDatabase.existingSecret) }}
+{{- if .Values.cnpg.enabled }}
+{{- $cluster := .Values.cnpg.cluster | default dict }}
+{{- if and (not $cluster.superuserSecret) $cluster.enableSuperuserAccess -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-externaldb" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
+  name: {{ printf "%s-cnpg-superuser" (include "common.names.fullname" .) | trunc 63 | trimSuffix "-" }}
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: veritable-ui
+    app.kubernetes.io/component: veritable-cloudagent
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -14,6 +16,8 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  password: {{ .Values.externalDatabase.password | b64enc | quote }}
-  postgres-password: {{ .Values.externalDatabase.postgresqlPostgresPassword | b64enc | quote }}
+  username: {{ "postgres" | b64enc | quote }}
+  password: {{ randAlphaNum 36 | b64enc | quote }}
+  pgpass: {{ randAlphaNum 36 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/veritable-ui/values.yaml
+++ b/charts/veritable-ui/values.yaml
@@ -786,3 +786,56 @@ externalCloudagent:
   ## @param externalCloudagent.url External veritable-cloudagent URL
   ##
   url: ""
+
+## @section cloudnative-pg (CNPG) cluster
+##
+## Ensure that the CNPG operator CRDs have already been installed before enabling.
+## https://github.com/cloudnative-pg/charts
+##
+## A comprehensive list of CNPG cluster values can be found here:
+## https://github.com/cloudnative-pg/charts/blob/main/charts/cluster/values.yaml
+##
+## @param cnpg.enabled Enable the cloudnative-pg cluster
+## @param cnpg.mode Cluster mode of operation ("standalone", "replica", or "recovery")
+## @param cnpg.type Type of backend ("postgresql" is recommended)
+## @param cnpg.version.postgresql Major PostgreSQL version to use
+##
+## Nb. To automatically perform a major version upgrade of the PostgreSQL instances,
+## increase this value incrementally to arrive at the target version.
+##
+## @param cnpg.cluster.imageName Long-form PostgreSQL GHCR image ID
+## @param cnpg.cluster.initdb [object] Details of the database object being created
+## @extra cnpg.cluster.initdb.secret.name Secret name for the database owner (expects "username"/"password" keys within secret)
+## e.g.
+    # initdb:
+      # database: example
+      # owner: example-owner
+      # secret:
+        # name: example-cnpg-app
+      # options: []
+      # encoding: UTF8
+      # postInitSQL:
+      #   - CREATE EXTENSION IF NOT EXISTS vector;
+      # postInitApplicationSQL: []
+      # postInitTemplateSQL: []
+## @param cnpg.cluster.instances Number of database replicas
+## @param cnpg.cluster.storage.size Instance storage capacity
+## @param cnpg.cluster.storage.storageClass Storage class
+## @param cnpg.cluster.enableSuperuserAccess Permit superuser access
+## @extra cnpg.cluster.superuserSecret Name of the superuser's secret (expects "pgpass"; uses a randomised password if enabled and left blank)
+cnpg:
+  enabled: true
+  type: postgresql
+  version:
+    postgresql: "17"
+  mode: standalone
+  cluster:
+    imageName: ""
+    initdb:
+      database: veritable-ui
+      owner: postgres
+    instances: 1
+    storage:
+      size: 5Gi
+      storageClass: ""
+    enableSuperuserAccess: true


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Bug Fix
- [x] Chore
- [x] Feature
- [x] Documentation Update
- [ ] Code style update (formatting, local variables)
- [x] Breaking Change (fix or feature that would cause existing functionality to change)

## Linked tickets

VR-473

## High level description

This request represents a major change to the backends of the Veritable applications, as I'm swapping out the Bitnami PostgreSQL values for cloudnative-pg ones as part of the migration away from Broadcom components throughout our stacks. While there are still Bitnami PostgreSQL backends enabled, for now, these are nothing but an interim measure to ensure a smooth transition from one provider to the other. Once that process has been confirmed as successful, I'll disable the Bitnami PostgreSQL subchart and remove it altogether.

## Detailed description

Both CNPG clusters are being initialised with a single database. Passwords are provided via secrets, rather than in-line values. On that point, `%s-cnpg-app` and `%s-cnpg-superuser` are the preferred patterns used internally by CNPG when creating new secrets, hence that same pattern has been reused here to ensure that the resources have the `password` and `pgpass` environment variables.

If `cnpg.cluster.initdb.secret.name` or `cnpg.cluster.superuserSecret` are blank, then the secrets will be created.

There are a few other CNPG values that need to be captured for the new clusters, particularly where the CNPG sub-chart defaults should be overridden, e.g. `cnpg.cluster.instances` or `cnpg.cluster.storage.size`, for convenience. With the values.yaml files here, I've overridden the default number of instances down from three to one. Storage size will vary across environments and should be overridden on a case-by-case basis.

There are some placeholder values under `charts/*/ci/ct-values.yaml` to ensure that the Bitnami PostgreSQL cluster is still handled correctly by the chart, even though it's no longer the functioning backend.

```yaml
global:
  postgresql:
    auth:
      password: password
```

These CI values will be removed at a later date, once we're ready to disable the Bitnami sub-chart altogether.

## Operational impact

Since these changes require the operator to be installed first, our existing CI workflows will need to be updated _before_ this is merged. They will need to be adding the CNPG repository and installing the operator before any other steps involving `helm install` or `helm upgrade`.

## Additional context

Broadcom are suspending the release of public images as part of their Bitnami Helm chart catalogue. To keep these charts up-to-date and secure, we're rolling out a series of updates to our own infrastructure to replace Bitnami charts and sub-charts with alternatives, such as cloudnative-pg.