### PR TITLE
chore: deprecate SQNC helm charts (ENG-318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,20 @@ A collection of [helm](https://helm.sh) charts created by [Digital Catapult](htt
 
 * [bridgeai-prediction-service](charts/bridgeai-prediction-service/README.md) - Deploy the bridgeai-prediction-service
 * [openapi-merger](charts/openapi-merger/README.md) - Deploy the openapi-merger
+* [veritable-cloudagent](charts/veritable-cloudagent/README.md) - Deploy the veritable-cloudagent
+* [veritable-ui](charts/veritable-ui/README.md) - Deploy the veritable-ui
+
+## Deprecated Chart List
+
+The SQNC (Sequence) charts below are deprecated and no longer maintained. The
+source repositories have been archived. They remain in the published index for
+existing deployments but should not be used for new installations.
+
+* [sqnc-attachment-api](charts/sqnc-attachment-api/README.md) - Deploy sqnc-attachment-api service
 * [sqnc-identity-service](charts/sqnc-identity-service/README.md) - Deploy sqnc-identity-service
 * [sqnc-ipfs](charts/sqnc-ipfs/README.md) - Deploy sqnc-ipfs
 * [sqnc-matchmaker-api](charts/sqnc-matchmaker-api/README.md) - Deploy sqnc-matchmaker-api service
-* [sqnc-attachment-api](charts/sqnc-attachment-api/README.md) - Deploy sqnc-attachment-api service
 * [sqnc-node](charts/sqnc-node/README.md) - Deploy sqnc-node
-* [veritable-cloudagent](charts/veritable-cloudagent/README.md) - Deploy the veritable-cloudagent
-* [veritable-ui](charts/veritable-ui/README.md) - Deploy the veritable-ui
 
 ---
 

--- a/charts/sqnc-attachment-api/Chart.yaml
+++ b/charts/sqnc-attachment-api/Chart.yaml
@@ -2,6 +2,7 @@ annotations:
   category: sqnc
   licenses: Apache-2.0
 apiVersion: v2
+deprecated: true
 # renovate: image=digicatapult/sqnc-attachment-api
 appVersion: v3.3.101
 dependencies:
@@ -59,4 +60,4 @@ maintainers:
 name: sqnc-attachment-api
 sources:
   - https://github.com/digicatapult/sqnc-attachment-api
-version: 3.2.28
+version: 3.2.29

--- a/charts/sqnc-attachment-api/Chart.yaml
+++ b/charts/sqnc-attachment-api/Chart.yaml
@@ -53,10 +53,6 @@ home: https://github.com/digicatapult/sqnc-documentation
 icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/assets/icon.png
 keywords:
   - SQNC
-maintainers:
-  - name: digicatapult  # Digital Catapult
-    url: https://github.com/digicatapult/helm-charts
-    email: opensource@digicatapult.org.uk
 name: sqnc-attachment-api
 sources:
   - https://github.com/digicatapult/sqnc-attachment-api

--- a/charts/sqnc-identity-service/Chart.yaml
+++ b/charts/sqnc-identity-service/Chart.yaml
@@ -2,6 +2,7 @@ annotations:
   category: sqnc
   licenses: Apache-2.0
 apiVersion: v2
+deprecated: true
 # renovate: image=digicatapult/sqnc-identity-service
 appVersion: v4.2.180
 dependencies:
@@ -33,4 +34,4 @@ maintainers:
 name: sqnc-identity-service
 sources:
   - https://github.com/digicatapult/sqnc-identity-service
-version: 5.1.173
+version: 5.1.174

--- a/charts/sqnc-identity-service/Chart.yaml
+++ b/charts/sqnc-identity-service/Chart.yaml
@@ -27,10 +27,6 @@ home: https://github.com/digicatapult/sqnc-documentation
 icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/assets/icon.png
 keywords:
   - SQNC
-maintainers:
-  - name: digicatapult  # Digital Catapult
-    url: https://github.com/digicatapult/helm-charts
-    email: opensource@digicatapult.org.uk
 name: sqnc-identity-service
 sources:
   - https://github.com/digicatapult/sqnc-identity-service

--- a/charts/sqnc-ipfs/Chart.yaml
+++ b/charts/sqnc-ipfs/Chart.yaml
@@ -2,11 +2,12 @@ annotations:
   category: sqnc
   licenses: Apache-2.0
 apiVersion: v2
+deprecated: true
 name: sqnc-ipfs
 description: sqnc-ipfs is a component of the SQNC project that provides a distributed IPFS based storage solution for the SQNC platform.
 # renovate: image=digicatapult/sqnc-ipfs
 appVersion: v3.0.110
-version: 4.1.39
+version: 4.1.40
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/charts/sqnc-ipfs/Chart.yaml
+++ b/charts/sqnc-ipfs/Chart.yaml
@@ -25,9 +25,5 @@ home: https://github.com/digicatapult/sqnc-documentation
 icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/assets/icon.png
 keywords:
   - SQNC
-maintainers:
-  - name: digicatapult  # Digital Catapult
-    url: https://github.com/digicatapult/helm-charts
-    email: opensource@digicatapult.org.uk
 sources:
   - https://github.com/digicatapult/sqnc-ipfs

--- a/charts/sqnc-matchmaker-api/Chart.yaml
+++ b/charts/sqnc-matchmaker-api/Chart.yaml
@@ -45,10 +45,6 @@ home: https://github.com/digicatapult/sqnc-documentation
 icon: https://raw.githubusercontent.com/digicatapult/sqnc-documentation/main/assets/icon.png
 keywords:
   - SQNC
-maintainers:
-  - name: digicatapult  # Digital Catapult
-    url: https://github.com/digicatapult/helm-charts
-    email: opensource@digicatapult.org.uk
 name: sqnc-matchmaker-api
 sources:
   - https://github.com/digicatapult/sqnc-matchmaker-api

--- a/charts/sqnc-matchmaker-api/Chart.yaml
+++ b/charts/sqnc-matchmaker-api/Chart.yaml
@@ -2,6 +2,7 @@ annotations:
   category: sqnc
   licenses: Apache-2.0
 apiVersion: v2
+deprecated: true
 # renovate: image=digicatapult/sqnc-matchmaker-api
 appVersion: v6.2.138
 dependencies:
@@ -51,4 +52,4 @@ maintainers:
 name: sqnc-matchmaker-api
 sources:
   - https://github.com/digicatapult/sqnc-matchmaker-api
-version: 4.1.199
+version: 4.1.200

--- a/charts/sqnc-node/Chart.yaml
+++ b/charts/sqnc-node/Chart.yaml
@@ -1,10 +1,6 @@
 apiVersion: v2
 deprecated: true
 name: sqnc-node
-maintainers:
-  - name: digicatapult
-    email: opensource@digicatapult.org.uk
-    url: www.digicatapult.org.uk
 description: A Helm chart to deploy SQNC nodes
 type: application
 version: 7.2.2

--- a/charts/sqnc-node/Chart.yaml
+++ b/charts/sqnc-node/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v2
+deprecated: true
 name: sqnc-node
 maintainers:
   - name: digicatapult
@@ -6,6 +7,6 @@ maintainers:
     url: www.digicatapult.org.uk
 description: A Helm chart to deploy SQNC nodes
 type: application
-version: 7.2.1
+version: 7.2.2
 # renovate: image=digicatapult/sqnc-node
 appVersion: "14.0.0"

--- a/renovate.config.js
+++ b/renovate.config.js
@@ -41,6 +41,18 @@ module.exports = (config = {}) => {
     ],
     packageRules: [
       {
+        description:
+          "Disable all updates for deprecated SQNC charts (ENG-318). Source repositories are archived; these charts are frozen.",
+        matchFileNames: [
+          "charts/sqnc-attachment-api/**",
+          "charts/sqnc-identity-service/**",
+          "charts/sqnc-ipfs/**",
+          "charts/sqnc-matchmaker-api/**",
+          "charts/sqnc-node/**",
+        ],
+        enabled: false,
+      },
+      {
         matchManagers: ["helm-values", "regex", "helmv3"],
         groupName: null,
         labels: ["dependencies", "helm"],


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

- [x] Chore

## Linked tickets

- https://digicatapult.atlassian.net/browse/ENG-318

## High level description

The SQNC (Sequence) codebase is being retired and its source repositories archived. This PR deprecates all five SQNC Helm charts published from this repository so that Helm warns against new installations while leaving existing published versions installable for current deployments.

## Detailed description

Each SQNC chart now sets `deprecated: true` in its `Chart.yaml` and has its patch version bumped. The version bump is required so that `chart-releaser` (run by the Release Charts workflow on push to `main`) packages a new release and carries the `deprecated` flag through into the published `index.yaml` on the `gh-pages` branch. Helm marks the whole chart as deprecated in the repo index when the latest version is deprecated.

Charts deprecated (version change):

- `sqnc-attachment-api` 3.2.28 → 3.2.29
- `sqnc-identity-service` 5.1.173 → 5.1.174
- `sqnc-ipfs` 4.1.39 → 4.1.40
- `sqnc-matchmaker-api` 4.1.199 → 4.1.200
- `sqnc-node` 7.2.1 → 7.2.2

The repository `README.md` has also been updated to move these charts into a new "Deprecated Chart List" section.

To stop these now-frozen charts from continuing to churn, a `renovate.config.js` `packageRule` (`enabled: false`) disables all renovate updates for the five SQNC chart directories. Without it, the regex image manager and the helmv3/helm-values managers would keep opening (and automerging) update PRs and, via the auto version bump + chart-releaser, keep publishing new releases of charts we have just deprecated. CI workflows are intentionally left unchanged so `release.yaml` can publish this deprecation and so the charts still lint if edited manually.

This is the Helm-charts portion of ENG-318. Archiving the SQNC source repositories is tracked separately in the same ticket and is not part of this PR.

## Describe alternatives you've considered

The ticket offered an alternative of removing the chart directories and re-indexing `gh-pages`. This was rejected because:

- `chart-releaser` only adds new versions to the index; it does not remove already-published versions, so deleting the directories would leave the old versions live but unmanaged and would require manual, error-prone editing of the `gh-pages` `index.yaml`.
- Deprecation via `deprecated: true` is the idiomatic Helm mechanism, is reversible, keeps existing deployments working, and flows through the existing release pipeline with no manual index surgery.

## Operational impact

- Existing installations are unaffected; previously published chart versions remain downloadable.
- After merge, the Release Charts workflow publishes the new deprecated versions to the `digicatapult` Helm repo index. `helm pull`/`helm install` of these charts will emit a deprecation warning.
- Fully reversible: revert the `deprecated: true` flag and bump the patch version again to publish a non-deprecated release.
- Before merging, confirm no active deployments or in-flight work depend on these charts (see ENG-318).

## Additional context

Part of the SQNC retirement work in ENG-318, alongside archiving the SQNC source repositories.
